### PR TITLE
Fix linker error caused by VLOG macro

### DIFF
--- a/include/log++.h
+++ b/include/log++.h
@@ -346,8 +346,16 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 
 #define LOG_STRING(severity, ptr) LPP_INTL::InternalGlogLogStringLog(toBase(LPP_INTL::GlogSeverity::severity), ptr)
 
-//! Replace google FLAGS_v if MODE_ROSLOG or MODE_LPP is used
+/**
+ * Replace glog's FLAGS_v and VLOG_IS_ON to avoid linker errors
+ * if glog is installed but not linked to lpp.
+ */
 inline static int32_t LPP_FLAGS_v;
+
+#ifdef GLOG_SUPPORTED
+#define FLAGS_v LPP_FLAGS_v
+#endif
+
 #undef VLOG_IS_ON
 #define VLOG_IS_ON(verboselevel) LPP_FLAGS_v >= (verboselevel) ? true : false
 #define VLOG(verboselevel) LPP_INTL::InternalCondLog(LPP_INTL::BaseSeverity::DEBUG, VLOG_IS_ON(verboselevel))

--- a/include/log++.h
+++ b/include/log++.h
@@ -346,10 +346,10 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 
 #define LOG_STRING(severity, ptr) LPP_INTL::InternalGlogLogStringLog(toBase(LPP_INTL::GlogSeverity::severity), ptr)
 
-#ifndef GLOG_SUPPORTED
-inline static int32_t FLAGS_v;
-#define VLOG_IS_ON(verboselevel) FLAGS_v >= (verboselevel) ? true : false
-#endif
+//! Replace google FLAGS_v if MODE_ROSLOG or MODE_LPP is used
+inline static int32_t LPP_FLAGS_v;
+#undef VLOG_IS_ON
+#define VLOG_IS_ON(verboselevel) LPP_FLAGS_v >= (verboselevel) ? true : false
 #define VLOG(verboselevel) LPP_INTL::InternalCondLog(LPP_INTL::BaseSeverity::DEBUG, VLOG_IS_ON(verboselevel))
 #endif
 

--- a/include/log++.h
+++ b/include/log++.h
@@ -356,7 +356,7 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
  * Replace glog's FLAGS_v and VLOG_IS_ON to avoid linker errors
  * if glog is installed but not linked to lpp.
  */
-inline static int32_t LPP_FLAGS_v;
+[[maybe_unused]] inline static int32_t LPP_FLAGS_v;
 
 #ifdef GLOG_SUPPORTED
 #define FLAGS_v LPP_FLAGS_v


### PR DESCRIPTION
If VLOG() is used in MODE_ROSLOG or MODE_LPP and glog is installed but not linked to lpp, a linker error is generated. This happens because VLOG() uses the FLAGS_v global variable and VLOG_IS_ON() macro. This PR replaces both of them with an lpp implementation if MODE_LPP or MODE_ROSLOG is used.