### PR TITLE
Added MODE_NOLOG

### DIFF
--- a/.github/scripts/run_build_ubuntu20_04.sh
+++ b/.github/scripts/run_build_ubuntu20_04.sh
@@ -37,10 +37,12 @@ cmake --build . --target test_default -- -j 6
 cmake --build . --target test_glog -- -j 6
 cmake --build . --target test_lpp -- -j 6
 cmake --build . --target test_lpp_custom -- -j 6
+cmake --build . --target test_nolog -- -j 6
 cmake --build . --target test_roslog -- -j 6
 cd devel/lib/lpp
 ./test_default
-./test_roslog
+./test_glog
 ./test_lpp
 ./test_lpp_custom
+./test_nolog
 ./test_roslog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/nolog/test_nolog_basic.cc
                 test/nolog/test_nolog_every_n.cc
                 test/nolog/test_nolog_first_n.cc
-                #test/nolog/test_nolog_if_every_n.cc
+                test/nolog/test_nolog_if_every_n.cc
                 #test/nolog/test_nolog_log_string.cc
                 #test/nolog/test_nolog_rosprintf.cc
                 #test/nolog/test_nolog_timed.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,9 +165,8 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/nolog/test_nolog_if_every_n.cc
                 test/nolog/test_nolog_log_string.cc
                 test/nolog/test_nolog_rosprintf.cc
-                #test/nolog/test_nolog_timed.cc
+                test/nolog/test_nolog_timed.cc
                 test/nolog/test_nolog_vlog.cc
-                #test/nolog/test_severity_conversions.cc
         )
 
         target_include_directories(${NOLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/nolog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,4 +155,24 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_link_libraries(${DEFAULT_TESTS} glog gtest ${catkin_LIBRARIES})
         target_compile_definitions(${DEFAULT_TESTS} PRIVATE MODE_DEFAULT)
         target_compile_options(${DEFAULT_TESTS} PRIVATE "-fcompare-debug-second")
+
+        ##### Nolog Tests #####
+        set(NOLOG_TESTS "test_nolog")
+        add_executable(${NOLOG_TESTS} test/test_entry_point.cpp
+                #test/nolog/test_common.cc
+                test/nolog/test_nolog_basic.cc
+                #test/nolog/test_nolog_every_n.cc
+                #test/nolog/test_nolog_first_n.cc
+                #test/nolog/test_nolog_if_every_n.cc
+                #test/nolog/test_nolog_log_string.cc
+                #test/nolog/test_nolog_rosprintf.cc
+                #test/nolog/test_nolog_timed.cc
+                #test/nolog/test_nolog_vlog.cc
+                #test/nolog/test_severity_conversions.cc
+        )
+
+        target_include_directories(${NOLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/nolog)
+        target_link_libraries(${NOLOG_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_compile_definitions(${NOLOG_TESTS} PRIVATE MODE_NOLOG)
+        target_compile_options(${NOLOG_TESTS} PRIVATE "-fcompare-debug-second")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,9 +159,8 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         ##### Nolog Tests #####
         set(NOLOG_TESTS "test_nolog")
         add_executable(${NOLOG_TESTS} test/test_entry_point.cpp
-                #test/nolog/test_common.cc
                 test/nolog/test_nolog_basic.cc
-                #test/nolog/test_nolog_every_n.cc
+                test/nolog/test_nolog_every_n.cc
                 #test/nolog/test_nolog_first_n.cc
                 #test/nolog/test_nolog_if_every_n.cc
                 #test/nolog/test_nolog_log_string.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/nolog/test_nolog_log_string.cc
                 test/nolog/test_nolog_rosprintf.cc
                 #test/nolog/test_nolog_timed.cc
-                #test/nolog/test_nolog_vlog.cc
+                test/nolog/test_nolog_vlog.cc
                 #test/nolog/test_severity_conversions.cc
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/nolog/test_nolog_first_n.cc
                 test/nolog/test_nolog_if_every_n.cc
                 test/nolog/test_nolog_log_string.cc
-                #test/nolog/test_nolog_rosprintf.cc
+                test/nolog/test_nolog_rosprintf.cc
                 #test/nolog/test_nolog_timed.cc
                 #test/nolog/test_nolog_vlog.cc
                 #test/nolog/test_severity_conversions.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/nolog/test_nolog_every_n.cc
                 test/nolog/test_nolog_first_n.cc
                 test/nolog/test_nolog_if_every_n.cc
-                #test/nolog/test_nolog_log_string.cc
+                test/nolog/test_nolog_log_string.cc
                 #test/nolog/test_nolog_rosprintf.cc
                 #test/nolog/test_nolog_timed.cc
                 #test/nolog/test_nolog_vlog.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         add_executable(${NOLOG_TESTS} test/test_entry_point.cpp
                 test/nolog/test_nolog_basic.cc
                 test/nolog/test_nolog_every_n.cc
-                #test/nolog/test_nolog_first_n.cc
+                test/nolog/test_nolog_first_n.cc
                 #test/nolog/test_nolog_if_every_n.cc
                 #test/nolog/test_nolog_log_string.cc
                 #test/nolog/test_nolog_rosprintf.cc

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ $ catkin build lpp
 - **MODE_GLOG:** Google Logging output. Calls abort() if it logs a fatal error.
 - **MODE_ROSLOG:** ROS Logging output.
 - **MODE_DEFAULT:** Disables Logging standardization. Messages are logged according to their framework.
+- **MODE_NOLOG:** Disables Logging completely. Useful for unittests or in some cases for release builds.
 
 ## How severity levels should be used
 

--- a/include/log++.h
+++ b/include/log++.h
@@ -474,11 +474,11 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define ROS_ERROR(...) LOG_2(E, LPP_INTL::emptyString(__VA_ARGS__))
 #define ROS_FATAL(...) LOG_2(F, LPP_INTL::emptyString(__VA_ARGS__))
 
-#define ROS_DEBUG_STREAM(x) (void) x
-#define ROS_INFO_STREAM(x) (void) x
-#define ROS_WARN_STREAM(x) (void) x
-#define ROS_ERROR_STREAM(x) (void) x
-#define ROS_FATAL_STREAM(x) (void) x
+#define ROS_DEBUG_STREAM(x) LPP_INTL::emptyString(x)
+#define ROS_INFO_STREAM(x) LPP_INTL::emptyString(x)
+#define ROS_WARN_STREAM(x) LPP_INTL::emptyString(x)
+#define ROS_ERROR_STREAM(x) LPP_INTL::emptyString(x)
+#define ROS_FATAL_STREAM(x) LPP_INTL::emptyString(x)
 
 #define ROS_DEBUG_ONCE(...) LOG_2(D, LPP_INTL::emptyString(__VA_ARGS__))
 #define ROS_INFO_ONCE(...) LOG_2(I, LPP_INTL::emptyString(__VA_ARGS__))

--- a/include/log++.h
+++ b/include/log++.h
@@ -449,22 +449,38 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define LOG_STRING(severity, ptr) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(ptr), std::vector<std::string>*>::value || std::is_same<decltype(ptr), std::nullptr_t>::value); InternalLog()
 
 //ros
+#define ROS_DEBUG(...) LOG_2(D, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_INFO(...) LOG_2(I, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_WARN(...) LOG_2(W, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_ERROR(...) LOG_2(E, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_FATAL(...) LOG_2(F, LPP_INTL::emptyString(__VA_ARGS__))
+
 #define ROS_DEBUG_STREAM(x) (void) x
 #define ROS_INFO_STREAM(x) (void) x
 #define ROS_WARN_STREAM(x) (void) x
 #define ROS_ERROR_STREAM(x) (void) x
 #define ROS_FATAL_STREAM(x) (void) x
 
-#define ROS_DEBUG_ONCE(x) (void) x
-#define ROS_INFO_ONCE(x) (void) x
-#define ROS_WARN_ONCE(x) (void) x
-#define ROS_ERROR_ONCE(x) (void) x
-#define ROS_FATAL_ONCE(x) (void) x
+#define ROS_DEBUG_ONCE(...) LOG_2(D, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_INFO_ONCE(...) LOG_2(I, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_WARN_ONCE(...) LOG_2(W, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_ERROR_ONCE(...) LOG_2(E, LPP_INTL::emptyString(__VA_ARGS__))
+#define ROS_FATAL_ONCE(...) LOG_2(F, LPP_INTL::emptyString(__VA_ARGS__))
 #endif
 
 namespace lpp {
 namespace internal {
+#ifdef MODE_NOLOG
+//! Used to disable logging for printf(3) like syntax
+template<typename... Args>
+constexpr inline std::string_view emptyString([[maybe_unused]] const char *f, [[maybe_unused]] Args... args) {
+  return "";
+}
 
+[[maybe_unused]] constexpr std::string_view emptyString([[maybe_unused]] const char *str) {
+  return "";
+}
+#endif
 //! Composes a string with the same text that would be printed if format was used on printf(3)
 template<typename... Args>
 inline std::string formatToString(const char *f, Args... args) {

--- a/include/log++.h
+++ b/include/log++.h
@@ -446,6 +446,7 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define LOG_FIRST_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
 #define DLOG_IF_EVERY_N(severity, cond, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(cond), bool>::value && std::is_integral_v<decltype(n)>); InternalLog()
 #define LOG_IF_EVERY_N(severity, cond, n) DLOG_IF_EVERY_N(severity, cond, n)
+#define LOG_STRING(severity, ptr) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(ptr), std::vector<std::string>*>::value || std::is_same<decltype(ptr), std::nullptr_t>::value); InternalLog()
 
 //ros
 #define ROS_DEBUG_STREAM(x) (void) x

--- a/include/log++.h
+++ b/include/log++.h
@@ -43,7 +43,7 @@
 #include <functional>
 #include <memory>
 
-#if !defined MODE_LPP && !defined MODE_GLOG && !defined MODE_ROSLOG && !defined MODE_DEFAULT
+#if !defined MODE_LPP && !defined MODE_GLOG && !defined MODE_ROSLOG && !defined MODE_DEFAULT && !defined MODE_NOLOG
 #define MODE_DEFAULT
 #warning "No mode defined. Selected MODE_DEFAULT";
 #endif
@@ -56,10 +56,11 @@
  *
  * Defining MODE_DEFAULT will prevent errors from being generated for each logging function that is called.
  */
-#if defined(MODE_LPP) + defined(MODE_GLOG) + defined(MODE_ROSLOG) + defined(MODE_DEFAULT) > 1
+#if defined(MODE_LPP) + defined(MODE_GLOG) + defined(MODE_ROSLOG) + defined(MODE_DEFAULT) + defined(MODE_NOLOG) > 1
 #undef MODE_LPP
 #undef MODE_GLOG
 #undef MODE_ROSLOG
+#undef MODE_NOLOG
 #define MODE_DEFAULT
 #error "More than one mode is defined"
 #endif
@@ -425,6 +426,22 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #if defined MODE_LPP || defined MODE_DEFAULT
 #define LOG_2(severity, x) LPP_INTL::InternalLog(LPP_INTL::LppSeverity::severity) << x // NOLINT(bugprone-macro-parentheses)
 #define LOG_3(severity, cond, x) if (cond) LPP_INTL::InternalLog(LPP_INTL::LppSeverity::severity) << x // NOLINT(bugprone-macro-parentheses)
+#endif
+
+
+//! MODE_NOLOG
+
+#ifdef MODE_NOLOG
+#define DLOG(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
+#define LOG_1(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
+
+#define LOG_2(severity, x) (void) LPP_INTL::LppSeverity::severity; InternalLog() << x
+
+#define ROS_DEBUG_STREAM(x) (void) x
+#define ROS_INFO_STREAM(x) (void) x
+#define ROS_WARN_STREAM(x) (void) x
+#define ROS_ERROR_STREAM(x) (void) x
+#define ROS_FATAL_STREAM(x) (void) x
 #endif
 
 namespace lpp {

--- a/include/log++.h
+++ b/include/log++.h
@@ -432,20 +432,32 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 //! MODE_NOLOG
 
 #ifdef MODE_NOLOG
-#define LOG_EVERY(severity, n, x) (void) LPP_INTL::LppSeverity::severity; InternalLog()
+//lpp
+#define LOG_2(severity, x) (void) LPP_INTL::LppSeverity::severity; InternalLog() << x
+#define LOG_EVERY(severity, n, x) (void) LPP_INTL::LppSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
+#define LOG_FIRST(severity, n, x) (void) LPP_INTL::LppSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
 
+//glog
+#define LOG_1(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 #define DLOG(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 #define DLOG_EVERY_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 #define LOG_EVERY_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
-#define LOG_1(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
+#define DLOG_FIRST_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
+#define LOG_FIRST_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
 
-#define LOG_2(severity, x) (void) LPP_INTL::LppSeverity::severity; InternalLog() << x
 
+//ros
 #define ROS_DEBUG_STREAM(x) (void) x
 #define ROS_INFO_STREAM(x) (void) x
 #define ROS_WARN_STREAM(x) (void) x
 #define ROS_ERROR_STREAM(x) (void) x
 #define ROS_FATAL_STREAM(x) (void) x
+
+#define ROS_DEBUG_ONCE(x) (void) x
+#define ROS_INFO_ONCE(x) (void) x
+#define ROS_WARN_ONCE(x) (void) x
+#define ROS_ERROR_ONCE(x) (void) x
+#define ROS_FATAL_ONCE(x) (void) x
 #endif
 
 namespace lpp {

--- a/include/log++.h
+++ b/include/log++.h
@@ -197,6 +197,17 @@ inline static Init lppInit;
 #undef ROS_WARN_ONCE
 #undef ROS_ERROR_ONCE
 #undef ROS_FATAL_ONCE
+
+#undef ROS_DEBUG_THROTTLE
+#undef ROS_DEBUG_STREAM_THROTTLE
+#undef ROS_INFO_THROTTLE
+#undef ROS_INFO_STREAM_THROTTLE
+#undef ROS_WARN_THROTTLE
+#undef ROS_WARN_STREAM_THROTTLE
+#undef ROS_ERROR_THROTTLE
+#undef ROS_ERROR_STREAM_THROTTLE
+#undef ROS_FATAL_THROTTLE
+#undef ROS_FATAL_STREAM_THROTTLE
 #endif
 
 using namespace lpp::internal;
@@ -437,6 +448,7 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define LOG_2(severity, x) (void) LPP_INTL::LppSeverity::severity; InternalLog() << x
 #define LOG_EVERY(severity, n, x) (void) LPP_INTL::LppSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
 #define LOG_FIRST(severity, n, x) (void) LPP_INTL::LppSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
+#define LOG_TIMED(severity, t, x) (void) LPP_INTL::LppSeverity::severity; static_assert(std::is_integral_v<decltype(t)>); InternalLog()
 
 //glog
 #define LOG_1(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
@@ -452,6 +464,8 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define VLOG_IF(verboselevel, condition) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_same<decltype(condition), bool>::value); InternalLog()
 #define VLOG_EVERY_N(verboselevel, n) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_integral_v<decltype(n)>); InternalLog()
 #define VLOG_IF_EVERY_N(verboselevel, condition, n) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_same<decltype(condition), bool>::value && std::is_integral_v<decltype(n)>); InternalLog()
+#define DLOG_EVERY_T(severity, t) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(t)>); InternalLog()
+#define LOG_EVERY_T(severity, t) DLOG_EVERY_T(severity, t)
 
 //ros
 #define ROS_DEBUG(...) LOG_2(D, LPP_INTL::emptyString(__VA_ARGS__))
@@ -471,6 +485,17 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define ROS_WARN_ONCE(...) LOG_2(W, LPP_INTL::emptyString(__VA_ARGS__))
 #define ROS_ERROR_ONCE(...) LOG_2(E, LPP_INTL::emptyString(__VA_ARGS__))
 #define ROS_FATAL_ONCE(...) LOG_2(F, LPP_INTL::emptyString(__VA_ARGS__))
+
+#define ROS_DEBUG_THROTTLE(t, x) static_assert(std::is_integral_v<decltype(t)>); LPP_INTL::emptyString(x)
+#define ROS_DEBUG_STREAM_THROTTLE(t, x) static_assert(std::is_integral_v<decltype(t)>); InternalLog()
+#define ROS_INFO_THROTTLE(t, x) ROS_DEBUG_THROTTLE(t, x)
+#define ROS_INFO_STREAM_THROTTLE(t, x) ROS_DEBUG_STREAM_THROTTLE(t, x)
+#define ROS_WARN_THROTTLE(t, x) ROS_DEBUG_THROTTLE(t, x)
+#define ROS_WARN_STREAM_THROTTLE(t, x) ROS_DEBUG_STREAM_THROTTLE(t, x)
+#define ROS_ERROR_THROTTLE(t, x) ROS_DEBUG_THROTTLE(t, x)
+#define ROS_ERROR_STREAM_THROTTLE(t, x) ROS_DEBUG_STREAM_THROTTLE(t, x)
+#define ROS_FATAL_THROTTLE(t, x) ROS_DEBUG_THROTTLE(t, x)
+#define ROS_FATAL_STREAM_THROTTLE(t, x) ROS_DEBUG_STREAM_THROTTLE(t, x)
 #endif
 
 namespace lpp {

--- a/include/log++.h
+++ b/include/log++.h
@@ -444,7 +444,8 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define LOG_EVERY_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 #define DLOG_FIRST_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
 #define LOG_FIRST_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_integral_v<decltype(n)>); InternalLog()
-
+#define DLOG_IF_EVERY_N(severity, cond, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(cond), bool>::value && std::is_integral_v<decltype(n)>); InternalLog()
+#define LOG_IF_EVERY_N(severity, cond, n) DLOG_IF_EVERY_N(severity, cond, n)
 
 //ros
 #define ROS_DEBUG_STREAM(x) (void) x

--- a/include/log++.h
+++ b/include/log++.h
@@ -510,6 +510,10 @@ constexpr inline std::string_view emptyString([[maybe_unused]] const char *f, [[
 [[maybe_unused]] constexpr std::string_view emptyString([[maybe_unused]] const char *str) {
   return "";
 }
+
+[[maybe_unused]] constexpr std::string_view emptyString([[maybe_unused]] const std::string& str) {
+  return "";
+}
 #endif
 //! Composes a string with the same text that would be printed if format was used on printf(3)
 template<typename... Args>

--- a/include/log++.h
+++ b/include/log++.h
@@ -358,6 +358,18 @@ true
 #define LOG_TIMED(severity, n, x) LPP_INTL::InternalLogCount::getInstance().update(LPP_GET_KEY(), n, LPP_INTL::InternalLog() << x, toBase(LPP_INTL::LppSeverity::severity), LPP_INTL::PolicyType::TIMED) // NOLINT(bugprone-macro-parentheses)
 #endif
 
+#if defined MODE_ROSLOG || defined MODE_LPP || MODE_NOLOG
+/**
+ * Replace glog's FLAGS_v and VLOG_IS_ON to avoid linker errors
+ * if glog is installed but not linked to lpp.
+ */
+[[maybe_unused]] inline static int32_t LPP_FLAGS_v;
+
+#ifdef GLOG_SUPPORTED
+#define FLAGS_v LPP_FLAGS_v
+#endif //GLOG_SUPPORTED
+#endif //defined MODE_ROSLOG || defined MODE_LPP || MODE_NOLOG
+
 #if defined MODE_ROSLOG || defined MODE_LPP
 #define LOG_EVERY_N(severity, n) LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::toBase(LPP_INTL::GlogSeverity::severity), LPP_INTL::PolicyType::EVERY_N)
 #define LOG_IF_EVERY_N(severity, condition, n) if (condition) LOG_EVERY_N(severity, n)
@@ -369,17 +381,6 @@ true
 LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP_INTL::PolicyType::FIRST_N)
 #define DLOG_IF_EVERY_N(severity, condition, n) LPP_ASSERT_GLOG(LPP_INTL::GlogSeverity::severity); if (condition) LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP_INTL::PolicyType::EVERY_N)
 #define LOG_STRING(severity, ptr) LPP_ASSERT_GLOG(LPP_INTL::GlogSeverity::severity); LPP_INTL::InternalGlogLogStringLog(toBase(LPP_INTL::GlogSeverity::severity), ptr)
-
-/**
- * Replace glog's FLAGS_v and VLOG_IS_ON to avoid linker errors
- * if glog is installed but not linked to lpp.
- */
-[[maybe_unused]] inline static int32_t LPP_FLAGS_v;
-
-#ifdef GLOG_SUPPORTED
-#define FLAGS_v LPP_FLAGS_v
-#endif
-
 
 #undef VLOG_IS_ON
 #define VLOG_IS_ON(verboselevel) LPP_FLAGS_v >= (verboselevel) ? true : false
@@ -447,6 +448,10 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 #define DLOG_IF_EVERY_N(severity, cond, n) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(cond), bool>::value && std::is_integral_v<decltype(n)>); InternalLog()
 #define LOG_IF_EVERY_N(severity, cond, n) DLOG_IF_EVERY_N(severity, cond, n)
 #define LOG_STRING(severity, ptr) (void) LPP_INTL::GlogSeverity::severity; static_assert(std::is_same<decltype(ptr), std::vector<std::string>*>::value || std::is_same<decltype(ptr), std::nullptr_t>::value); InternalLog()
+#define VLOG(verboselevel) static_assert(std::is_integral_v<decltype(verboselevel)>); InternalLog()
+#define VLOG_IF(verboselevel, condition) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_same<decltype(condition), bool>::value); InternalLog()
+#define VLOG_EVERY_N(verboselevel, n) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_integral_v<decltype(n)>); InternalLog()
+#define VLOG_IF_EVERY_N(verboselevel, condition, n) static_assert(std::is_integral_v<decltype(verboselevel)> && std::is_same<decltype(condition), bool>::value && std::is_integral_v<decltype(n)>); InternalLog()
 
 //ros
 #define ROS_DEBUG(...) LOG_2(D, LPP_INTL::emptyString(__VA_ARGS__))

--- a/include/log++.h
+++ b/include/log++.h
@@ -432,7 +432,11 @@ LPP_INTL::InternalPolicyLog(LPP_GET_KEY(), n, LPP_INTL::BaseSeverity::DEBUG, LPP
 //! MODE_NOLOG
 
 #ifdef MODE_NOLOG
+#define LOG_EVERY(severity, n, x) (void) LPP_INTL::LppSeverity::severity; InternalLog()
+
 #define DLOG(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
+#define DLOG_EVERY_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
+#define LOG_EVERY_N(severity, n) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 #define LOG_1(severity) (void) LPP_INTL::GlogSeverity::severity; InternalLog()
 
 #define LOG_2(severity, x) (void) LPP_INTL::LppSeverity::severity; InternalLog() << x

--- a/test/common/async_tests.h
+++ b/test/common/async_tests.h
@@ -44,7 +44,7 @@ class TestResult {
    * @return true on success otherwise false
    */
   inline bool get(const std::string &test_name) {
-    test_result_mutex_.lock();
+    std::scoped_lock<std::mutex> lock(test_result_mutex_);
     LOG_INIT(*test_argv);
     if (!started_) {
       started_ = true;
@@ -56,7 +56,6 @@ class TestResult {
     }
 
     bool res = test_results.at(test_name);
-    test_result_mutex_.unlock();
     return res;
   }
 

--- a/test/lpp/test_lpp_rosprintf.cc
+++ b/test/lpp/test_lpp_rosprintf.cc
@@ -8,62 +8,72 @@
 
 using namespace lpp::testing;
 
+TEST(lpp_rosprintf, ros_debug) {
+    LOG_INIT(*test_argv);
+
+    std::string output = LPP_CAPTURE_STDOUT(ROS_DEBUG(ERROR_MESSAGE, 3.3, 5.5));
+    ASSERT_EQ(output, "DEBUG " + EXPECTED_ERROR_MESSAGE);
+}
+
+TEST(lpp_rosprintf, ros_debug_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_DEBUG_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "DEBUG " + EXPECTED_ERROR_MESSAGE);
+}
+
 TEST(lpp_rosprintf, ros_info) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_INFO(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
-
-  ASSERT_EQ(c, "INFO  " + EXPECTED_ERROR_MESSAGE);
+  std::string output = LPP_CAPTURE_STDOUT(ROS_INFO(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "INFO  " + EXPECTED_ERROR_MESSAGE);
 }
 
 TEST(lpp_rosprintf, ros_info_once) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_INFO_ONCE(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
-
-  ASSERT_EQ(c, "INFO  " + EXPECTED_ERROR_MESSAGE);
+  std::string output = LPP_CAPTURE_STDOUT(ROS_INFO_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "INFO  " + EXPECTED_ERROR_MESSAGE);
 }
 
 TEST(lpp_rosprintf, ros_warn) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_WARN(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
-
-  ASSERT_EQ(c, "WARN  " + EXPECTED_ERROR_MESSAGE);
+  std::string output = LPP_CAPTURE_STDOUT(ROS_WARN(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "WARN  " + EXPECTED_ERROR_MESSAGE);
 }
 
 TEST(lpp_rosprintf, ros_warn_once) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_WARN_ONCE(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
-
-  ASSERT_EQ(c, "WARN  " + EXPECTED_ERROR_MESSAGE);
+  std::string output = LPP_CAPTURE_STDOUT(ROS_WARN_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "WARN  " + EXPECTED_ERROR_MESSAGE);
 }
 
 TEST(lpp_rosprintf, ros_error) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_ERROR(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
-
-  ASSERT_EQ(c, "ERROR " + EXPECTED_ERROR_MESSAGE);
+  std::string output = LPP_CAPTURE_STDOUT(ROS_ERROR(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "ERROR " + EXPECTED_ERROR_MESSAGE);
 }
 
 TEST(lpp_rosprintf, ros_error_once) {
   LOG_INIT(*test_argv);
 
-  testing::internal::CaptureStdout();
-  ROS_ERROR_ONCE(ERROR_MESSAGE, 3.3, 5.5);
-  std::string c = testing::internal::GetCapturedStdout();
+  std::string output = LPP_CAPTURE_STDOUT(ROS_ERROR_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ(output, "ERROR " + EXPECTED_ERROR_MESSAGE);
+}
 
-  ASSERT_EQ(c, "ERROR "  + EXPECTED_ERROR_MESSAGE);
+TEST(lpp_rosprintf, ros_fatal) {
+    LOG_INIT(*test_argv);
+
+    std::string output = LPP_CAPTURE_STDOUT(ROS_FATAL(ERROR_MESSAGE, 3.3, 5.5));
+    ASSERT_EQ(output, "FATAL " + EXPECTED_ERROR_MESSAGE);
+}
+
+TEST(lpp_rosprintf, ros_fatal_once) {
+    LOG_INIT(*test_argv);
+
+    std::string output = LPP_CAPTURE_STDOUT(ROS_FATAL_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+    ASSERT_EQ(output, "FATAL " + EXPECTED_ERROR_MESSAGE);
 }

--- a/test/lpp/test_lpp_vlog.cc
+++ b/test/lpp/test_lpp_vlog.cc
@@ -120,6 +120,9 @@ TEST(lpp_vlog, glog_syntax_every_n_severity_v5) {
 }
 
 TEST(lpp_vlog, glog_syntax_if_every_n_severity_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
   for (int i = 0; i < 5; i++) {
     testing::internal::CaptureStdout();
     VLOG_IF_EVERY_N(1, i <= 3, 3) << "Test" << 123;
@@ -134,6 +137,9 @@ TEST(lpp_vlog, glog_syntax_if_every_n_severity_v1) {
 }
 
 TEST(lpp_vlog, glog_syntax_if_every_n_severity_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
   for (int i = 0; i < 5; i++) {
     testing::internal::CaptureStdout();
     VLOG_IF_EVERY_N(3, i <= 3, 3) << "Test" << 123;

--- a/test/nolog/test_nolog_basic.cc
+++ b/test/nolog/test_nolog_basic.cc
@@ -1,0 +1,108 @@
+//
+// Created by acey on 06.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <test_utils.h>
+#include <log++.h>
+
+TEST(nolog_basic, glog_syntax_severity_debug){
+  LOG_INIT(*test_argv);
+  DLOG(INFO) << "TEst";
+
+  std::string output = LPP_CAPTURE_STDOUT(DLOG(INFO) << "Test");
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, glog_syntax_severity_info){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(LOG(INFO) << "Test123");
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, glog_syntax_severity_warning){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(LOG(WARNING) << "Test");
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, glog_syntax_severity_error){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(LOG(ERROR) << "Test");
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, glog_syntax_severity_fatal){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(LOG(FATAL) << "Test");
+  ASSERT_EQ("", output);
+}
+
+//! ################ lpp ################
+TEST(nolog_basic, lpp_syntax_severity_debug){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(LOG(D, "" << "Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, lpp_syntax_severity_info){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(LOG(I, "" << "Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, lpp_syntax_severity_warning){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(LOG(W, "" << "Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, lpp_syntax_severity_error){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(LOG(E, "" << "Test"));
+  ASSERT_EQ("", output);
+}
+
+//! ################ Roslog ################
+TEST(nolog_basic, roslog_syntax_severity_debug){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_DEBUG_STREAM("Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, roslog_syntax_severity_info){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_INFO_STREAM("Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, roslog_syntax_severity_warning){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_WARN_STREAM("Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, roslog_syntax_severity_error){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_ERROR_STREAM("Test"));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_basic, roslog_syntax_severity_fatal){
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_FATAL_STREAM("Test"));
+  ASSERT_EQ("", output);
+}

--- a/test/nolog/test_nolog_every_n.cc
+++ b/test/nolog/test_nolog_every_n.cc
@@ -1,0 +1,102 @@
+//
+// Created by acey on 06.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <log++.h>
+#include <test_utils.h>
+
+TEST(nolog_LogEveryN, lpp_syntax_severity_debug) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(LOG_EVERY(D, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, lpp_syntax_severity_info) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(LOG_EVERY(I, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, lpp_syntax_severity_warning) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_EVERY(W, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, lpp_syntax_severity_error) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_EVERY(E, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, lpp_syntax_severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_EVERY(F, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, glog_syntax_severity_debug) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDOUT(DLOG_EVERY_N(INFO, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, glog_syntax_severity_info) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDOUT(LOG_EVERY_N(INFO, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, glog_syntax_severity_warning) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_EVERY_N(WARNING, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, glog_syntax_severity_error) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_EVERY_N(ERROR, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogEveryN, glog_syntax_severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_EVERY_N(FATAL, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}

--- a/test/nolog/test_nolog_first_n.cc
+++ b/test/nolog/test_nolog_first_n.cc
@@ -1,0 +1,147 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <log++.h>
+#include <test_utils.h>
+
+TEST(nolog_LogFirstN, lpp_syntax_severity_debug) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(LOG_FIRST(D, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, lpp_syntax_severity_info) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(LOG_FIRST(I, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, lpp_syntax_severity_warning) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_FIRST(W, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, lpp_syntax_severity_error) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_FIRST(E, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, lpp_syntax_severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_FIRST(F, 3, "Test" << 123));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, glog_syntax_severity_debug) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDOUT(DLOG_FIRST_N(INFO, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, glog_syntax_severity_info) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDOUT(LOG_FIRST_N(INFO, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, glog_syntax_severity_warning) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_FIRST_N(WARNING, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, glog_syntax_severity_error) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_FIRST_N(ERROR, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, glog_syntax_severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output =
+        LPP_CAPTURE_STDERR(LOG_FIRST_N(FATAL, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, ros_debug_once) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(ROS_DEBUG_ONCE("Test123"));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, ros_info_once) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(ROS_INFO_ONCE("Test123"));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, ros_warn_once) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(ROS_WARN_ONCE("Test123"));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, ros_error_once) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(ROS_ERROR_ONCE("Test123"));
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_LogFirstN, ros_fatal_once) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(ROS_FATAL_ONCE("Test123"));
+    ASSERT_EQ(output, "");
+  }
+}

--- a/test/nolog/test_nolog_if_every_n.cc
+++ b/test/nolog/test_nolog_if_every_n.cc
@@ -1,0 +1,53 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <log++.h>
+#include <test_utils.h>
+
+TEST(nolog_if_every_n, glog_syntax_if_every_n_severity_debug) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(DLOG_IF_EVERY_N(INFO, i <= 3, 3) << "Test" << 12);
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_if_every_n, glog_syntax_if_every_n_severity_info) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(LOG_IF_EVERY_N(INFO, i <= 3, 3) << "Test" << 12);
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_if_every_n, glog_syntax_if_every_n_severity_warning) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_IF_EVERY_N(WARNING, i <= 3, 3) << "Test" << 12);
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_if_every_n, glog_syntax_if_every_n_severity_error) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_IF_EVERY_N(ERROR, i <= 3, 3) << "Test" << 12);
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_if_every_n, glog_syntax_if_every_n_severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDERR(LOG_IF_EVERY_N(FATAL, i <= 3, 3) << "Test" << 12);
+    ASSERT_EQ("", output);
+  }
+}
+

--- a/test/nolog/test_nolog_log_string.cc
+++ b/test/nolog/test_nolog_log_string.cc
@@ -1,0 +1,83 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <log++.h>
+#include <test_utils.h>
+
+TEST(nolog_log_string, severity_info) {
+  LOG_INIT(*test_argv);
+
+  std::vector<std::string> errors;
+
+  LOG_STRING(INFO, &errors) << "LOG_STRING: "
+                            << "collected info";
+  ASSERT_TRUE(errors.empty());
+}
+
+TEST(nolog_log_string, severity_info_null) {
+  LOG_INIT(*test_argv);
+
+  std::string output =
+      LPP_CAPTURE_STDOUT(LOG_STRING(INFO, nullptr) << "LOG_STRING: "
+                                                   << "collected info");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_log_string, severity_warning) {
+  LOG_INIT(*test_argv);
+
+  std::vector<std::string> errors;
+
+  LOG_STRING(WARNING, &errors) << "LOG_STRING: "
+                               << "collected warn";
+  ASSERT_TRUE(errors.empty());
+}
+
+TEST(nolog_log_string, severity_warning_null) {
+  LOG_INIT(*test_argv);
+
+  std::string output =
+      LPP_CAPTURE_STDOUT(LOG_STRING(WARNING, nullptr) << "LOG_STRING: "
+                                                      << "collected warn");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_log_string, severity_error) {
+  LOG_INIT(*test_argv);
+
+  std::vector<std::string> errors;
+
+  LOG_STRING(ERROR, &errors) << "LOG_STRING: "
+                             << "collected error";
+  ASSERT_TRUE(errors.empty());
+}
+
+TEST(nolog_log_string, severity_error_null) {
+  LOG_INIT(*test_argv);
+
+  std::string output =
+      LPP_CAPTURE_STDOUT(LOG_STRING(ERROR, nullptr) << "LOG_STRING: "
+                                                    << "collected error");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_log_string, severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  std::vector<std::string> errors;
+
+  LOG_STRING(ERROR, &errors) << "LOG_STRING: "
+                             << "collected error";
+  ASSERT_TRUE(errors.empty());
+}
+
+TEST(nolog_log_string, severity_fatal_null) {
+  LOG_INIT(*test_argv);
+
+  std::string output =
+      LPP_CAPTURE_STDOUT(LOG_STRING(FATAL, nullptr) << "LOG_STRING: "
+                                                    << "collected fatal");
+  ASSERT_EQ(output, "");
+}

--- a/test/nolog/test_nolog_rosprintf.cc
+++ b/test/nolog/test_nolog_rosprintf.cc
@@ -1,0 +1,79 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <test_utils.h>
+#include <log++.h>
+
+using namespace lpp::testing;
+
+TEST(nolog_rosprintf, severity_debug) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_DEBUG(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_debug_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_DEBUG_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_info) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_INFO(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_info_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDOUT(ROS_INFO_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_warn) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_WARN(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_warn_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_WARN_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_error) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_ERROR(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_error_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_ERROR_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_fatal) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_FATAL(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}
+
+TEST(nolog_rosprintf, severity_fatal_once) {
+  LOG_INIT(*test_argv);
+
+  std::string output = LPP_CAPTURE_STDERR(ROS_FATAL_ONCE(ERROR_MESSAGE, 3.3, 5.5));
+  ASSERT_EQ("", output);
+}

--- a/test/nolog/test_nolog_timed.cc
+++ b/test/nolog/test_nolog_timed.cc
@@ -1,0 +1,115 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <log++.h>
+#include <mutex>
+#include <async_tests.h>
+
+std::vector<AsyncTest> generateTests() {
+  return {
+      {"nolog_timed_lpp_syntax_severity_debug_Test","",[]() { LOG_TIMED(D, 1, "Test" << 123); }, EQUAL, STDOUT},
+      {"nolog_timed_lpp_syntax_severity_info_Test","",[]() { LOG_TIMED(I, 1, "Test" << 123); }, EQUAL, STDOUT},
+      {"nolog_timed_lpp_syntax_severity_warning_Test","",[]() { LOG_TIMED(W, 1, "Test" << 123); }, EQUAL, STDOUT},
+      {"nolog_timed_lpp_syntax_severity_error_Test","",[]() { LOG_TIMED(E, 1, "Test" << 123); }, EQUAL, STDOUT},
+      {"nolog_timed_lpp_syntax_severity_fatal_Test","",[]() { LOG_TIMED(F, 1, "Test" << 123); }, EQUAL, STDOUT},
+
+      {"nolog_timed_glog_syntax_severity_debug_Test","",[]() { DLOG_EVERY_T(INFO, 1) << "Test" << 123; }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_glog_syntax_severity_info_Test","",[]() { LOG_EVERY_T(INFO, 1) << "Test" << 123; }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_glog_syntax_severity_warning_Test","",[]() { LOG_EVERY_T(WARNING, 1) << "Test" << 123; }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_glog_syntax_severity_error_Test","",[]() { LOG_EVERY_T(ERROR, 1) << "Test" << 123; }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_glog_syntax_severity_fatal_Test","",[]() { LOG_EVERY_T(FATAL, 1) << "Test" << 123; }, IS_SUBSTRING, STDOUT},
+
+      {"nolog_timed_ros_syntax_severity_debug_Test", "", []() {ROS_DEBUG_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_ros_syntax_severity_debug_stream_Test", "", []() {ROS_DEBUG_STREAM_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_ros_syntax_severity_info_Test", "", []() {ROS_INFO_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_ros_syntax_severity_info_stream_Test", "", []() {ROS_INFO_STREAM_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDOUT},
+      {"nolog_timed_ros_syntax_severity_warning_Test", "", []() {ROS_WARN_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_ros_syntax_severity_warning_stream_Test", "", []() {ROS_WARN_STREAM_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_ros_syntax_severity_error_Test", "", []() {ROS_ERROR_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_ros_syntax_severity_error_stream_Test", "", []() {ROS_ERROR_STREAM_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_ros_syntax_severity_fatal_Test", "", []() {ROS_FATAL_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+      {"nolog_timed_ros_syntax_severity_fatal_stream_Test", "", []() {ROS_FATAL_STREAM_THROTTLE(1, "Test123"); }, IS_SUBSTRING, STDERR},
+  };
+}
+
+TEST(nolog_timed, lpp_syntax_severity_debug) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, lpp_syntax_severity_info) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, lpp_syntax_severity_warning) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, lpp_syntax_severity_error) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, lpp_syntax_severity_fatal) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, glog_syntax_severity_debug) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, glog_syntax_severity_info) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, glog_syntax_severity_warning) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, glog_syntax_severity_error) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, glog_syntax_severity_fatal) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_debug) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_debug_stream) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_info) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_info_stream) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_warning) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_warning_stream) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_error) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_error_stream) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_fatal) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}
+
+TEST(nolog_timed, ros_syntax_severity_fatal_stream) {
+  ASSERT_TRUE(TestResult::getInstance().get(GET_CLASS_NAME(*this, nullptr)));
+}

--- a/test/nolog/test_nolog_vlog.cc
+++ b/test/nolog/test_nolog_vlog.cc
@@ -1,0 +1,150 @@
+//
+// Created by acey on 07.09.23.
+//
+
+#include <gtest/gtest.h>
+#include <test_utils.h>
+#include <log++.h>
+
+TEST(nolog_vlog, glog_syntax_severity_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG(1) << "Test" << 123);
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG(3) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_v5) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG(5) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_if_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(1, true) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_if_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(3, true) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_if_v5) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(5, true) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_ifnot_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(1, false) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_ifnot_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(3, false) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_severity_ifnot_v5) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  std::string output = LPP_CAPTURE_STDOUT(VLOG_IF(5, false) << "Test123");
+  ASSERT_EQ(output, "");
+}
+
+TEST(nolog_vlog, glog_syntax_every_n_severity_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(VLOG_EVERY_N(1, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_vlog, glog_syntax_every_n_severity_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(VLOG_EVERY_N(3, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_vlog, glog_syntax_every_n_severity_v5) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    std::string output = LPP_CAPTURE_STDOUT(VLOG_EVERY_N(5, 3) << "Test" << 123);
+    ASSERT_EQ(output, "");
+  }
+}
+
+TEST(nolog_vlog, glog_syntax_if_every_n_severity_v1) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    testing::internal::CaptureStdout();
+    VLOG_IF_EVERY_N(1, i <= 3, 3) << "Test" << 123;
+    std::string output = testing::internal::GetCapturedStdout();
+
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_vlog, glog_syntax_if_every_n_severity_v3) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    testing::internal::CaptureStdout();
+    VLOG_IF_EVERY_N(3, i <= 3, 3) << "Test" << 123;
+    std::string output = testing::internal::GetCapturedStdout();
+
+    ASSERT_EQ("", output);
+  }
+}
+
+TEST(nolog_vlog, glog_syntax_if_every_n_severity_v5) {
+  LOG_INIT(*test_argv);
+  FLAGS_v = 3;
+
+  for (int i = 0; i < 5; i++) {
+    testing::internal::CaptureStdout();
+    VLOG_IF_EVERY_N(5, i <= 3, 3) << "Test" << 123;
+    std::string output = testing::internal::GetCapturedStdout();
+
+    ASSERT_EQ("", output);
+  }
+}
+
+


### PR DESCRIPTION
Added MODE_NOLOG to disable logging completely. Useful for unittests where logging can be ignored or in some cases for release builds.

- Implemented MODE_NOLOG
- Added Unittest suite for MODE_NOLOG
- Fixed and refactored some MODE_LPP unittests
- Fixed potential deadlock in `async_tests.h`