### PR TITLE
Added code coverage in CI

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,3 +1,4 @@
+name: Generate coverage report
 on:
   pull_request:
     branches:
@@ -8,7 +9,6 @@ on:
 
 jobs:
   build:
-    name: Generate coverage report
     runs-on: [self-hosted, linux]
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   build:
     name: Generate coverage report
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.url }}
     runs-on: [self-hosted, linux]
     strategy:
       fail-fast: false
@@ -20,9 +17,6 @@ jobs:
         gcc: ['10']
         cxx: ['17']
     container: ros:${{ matrix.rosdistro }}-ros-base-focal
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
     steps:
       - uses: actions/checkout@v3
         name: Checkout lpp

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,0 +1,64 @@
+name: Coverage report
+on:
+  push:
+      branches:
+      - "master"
+      - "feature/coverage"
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.url }}
+    runs-on: [self-hosted, linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro: ['noetic']
+        gcc: ['10']
+        cxx: ['17']
+    container: ros:${{ matrix.rosdistro }}-ros-base-focal
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout lpp
+        with:
+          repository: ethz-asl/lpp
+          token: ${{ secrets.PAT }}
+          path: catkin_ws/src/lpp
+
+      - name: Install newest git version
+        run: sudo apt update && sudo apt-get install -y software-properties-common && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+
+      - name: Install GCC version ${{ matrix.gcc }}
+        run: sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y && sudo apt update && sudo apt install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }} && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc }}
+
+      - name: Install catkin tools
+        run: sudo apt install -y python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential python3-catkin-tools
+
+      - name: Install system dependencies
+        run: sudo apt install -y libgoogle-glog-dev
+
+      - name: Install gcovr
+        run: sudo apt install -y gcovr
+
+      - name: Build lpp
+        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
+        working-directory: catkin_ws/src/lpp
+        shell: bash
+
+      - name: Run unittests
+        run: ./test_default && ./test_glog && ./test_lpp && ./test_lpp_custom && ./test_nolog && ./test_roslog
+        working-directory: catkin_ws/src/lpp/build/devel/lib/lpp
+        shell: bash
+
+      - name: Generate coverage report
+        run: make coverage
+        working-directory: catkin_ws/src/lpp/build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+            path: ${{runner.temp}}/catkin_ws/src/lpp/build/coverage"
+
+
+

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-            path: .
+            path: ./catkin_ws/src/lpp/build/coverage
 
 
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -55,16 +55,23 @@ jobs:
         working-directory: catkin_ws/src/lpp/build/devel/lib/lpp
         shell: bash
 
+      - name: Print coverage
+        run: gcovr
+        working-directory: catkin_ws/src/lpp
+
       - name: Generate coverage report
+        if: github.ref == 'refs/heads/master'
         run: make coverage
         working-directory: catkin_ws/src/lpp/build
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
             path: ./catkin_ws/src/lpp/build/coverage
 
       - name: Deploy to Github pages
+        if: github.ref == 'refs/heads/master'
         uses: actions/deploy-pages@v4
         id: deployment
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
 
       - name: Run unittests
-        run: ./test_default && ./test_glog && ./test_lpp && ./test_lpp_custom && ./test_nolog && ./test_roslog
+        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && ./test_default && ./test_glog && ./test_lpp && ./test_lpp_custom && ./test_nolog && ./test_roslog
         working-directory: catkin_ws/src/lpp/build/devel/lib/lpp
         shell: bash
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -19,6 +19,9 @@ jobs:
         gcc: ['10']
         cxx: ['17']
     container: ros:${{ matrix.rosdistro }}-ros-base-focal
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     steps:
       - uses: actions/checkout@v3
         name: Checkout lpp

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    name: Deploy coverage report
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.url }}
@@ -43,6 +44,8 @@ jobs:
 
       - name: Source ROS
         run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash
+        working-directory: catkin_ws
+        shell: bash
 
       - name: Build lpp
         run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-            path: ${{runner.temp}}/../lpp/lpp/catkin_ws/src/lpp/build/coverage"
+            path: .
 
 
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -42,13 +42,8 @@ jobs:
       - name: Install gcovr
         run: sudo apt install -y gcovr
 
-      - name: Source ROS
-        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash
-        working-directory: catkin_ws
-        shell: bash
-
       - name: Build lpp
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
+        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
         working-directory: catkin_ws/src/lpp
         shell: bash
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -61,5 +61,9 @@ jobs:
         with:
             path: ./catkin_ws/src/lpp/build/coverage
 
+      - name: Deploy to Github pages
+        uses: actions/deploy-pages@v4
+        id: deployment
+
 
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-            path: ${{runner.temp}}/catkin_ws/src/lpp/build/coverage"
+            path: ${{runner.temp}}/../lpp/lpp/catkin_ws/src/lpp/build/coverage"
 
 
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install gcovr
         run: sudo apt install -y gcovr
 
+      - name: Source ROS
+        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash
+
       - name: Build lpp
         run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
         working-directory: catkin_ws/src/lpp

--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: ['noetic']
-        gcc: ['8', '9', '10']
+        gcc: ['8', '9', '10', '11']
         cxx: ['11', '14', '17']
     container: ros:${{ matrix.rosdistro }}-ros-base-focal
     name: ROS ${{ matrix.rosdistro }} - GCC ${{ matrix.gcc }} - C++${{ matrix.cxx }}
@@ -30,7 +30,7 @@ jobs:
       run: sudo apt update && sudo apt-get install -y software-properties-common && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
 
     - name: Install GCC version ${{ matrix.gcc }}
-      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y && sudo apt update && sudo apt install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }} && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc }}
+      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && sudo apt update && sudo apt install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }} && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc }}
 
     - name: Install catkin tools
       run: sudo apt install -y python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential python3-catkin-tools

--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -1,5 +1,8 @@
 name: lpp
 on:
+  pull_request:
+    branches:
+      - "master"
   push:
     branches:
       - "master"

--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -1,8 +1,5 @@
 name: lpp
 on:
-  pull_request:
-    branches:
-      - "master"
   push:
     branches:
       - "master"

--- a/.github/workflows/deploy_coverage_report.yml
+++ b/.github/workflows/deploy_coverage_report.yml
@@ -1,14 +1,12 @@
+name: Coverage report
 on:
-  pull_request:
-    branches:
-      - "master"
   push:
-      branches:
+    branches:
       - "master"
 
 jobs:
-  build:
-    name: Generate coverage report
+  deploy:
+    name: Deploy coverage report
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.url }}
@@ -56,9 +54,18 @@ jobs:
         working-directory: catkin_ws/src/lpp/build/devel/lib/lpp
         shell: bash
 
-      - name: Print coverage
-        run: gcovr
-        working-directory: catkin_ws/src/lpp
+      - name: Generate coverage report
+        run: make coverage
+        working-directory: catkin_ws/src/lpp/build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./catkin_ws/src/lpp/build/coverage
+
+      - name: Deploy to Github pages
+        uses: actions/deploy-pages@v4
+        id: deployment
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         set(LPP_BUILD_TESTS 1)
 endif ()
 
+if (ENABLE_COVERAGE)
+        set(LPP_TEST_CXX_FLAGS ${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage)
+        message(STATUS "Coverage enabled")
+else ()
+        set(LPP_TEST_CXX_FLAGS ${CMAKE_CXX_FLAGS} -fcompare-debug-second)
+endif ()
+
 # Set standard of top level project or C++17
 if (NOT DEFINED CMAKE_CXX_STANDARD)
         set(CMAKE_CXX_STANDARD 17)
@@ -87,7 +94,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${GLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/glog)
         target_link_libraries(${GLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${GLOG_TESTS} PRIVATE MODE_GLOG)
-        target_compile_options(${GLOG_TESTS} PRIVATE ${CMAKE_CXX_FLAGS} "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${GLOG_TESTS} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         ##### Log++ Tests #####
         set(LPP_TESTS "test_lpp")
@@ -103,7 +110,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${LPP_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/lpp)
         target_link_libraries(${LPP_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${LPP_TESTS} PRIVATE MODE_LPP)
-        target_compile_options(${LPP_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${LPP_TESTS} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         ##### Log++ Custom Output Tests #####
         set(LPP_TESTS_CUSTOM "test_lpp_custom")
@@ -120,7 +127,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${LPP_TESTS_CUSTOM} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/lpp)
         target_link_libraries(${LPP_TESTS_CUSTOM} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${LPP_TESTS_CUSTOM} PRIVATE MODE_LPP)
-        target_compile_options(${LPP_TESTS_CUSTOM} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${LPP_TESTS_CUSTOM} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         ##### Roslog Tests #####
         set(ROSLOG_TESTS "test_roslog")
@@ -136,7 +143,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${ROSLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/roslog)
         target_link_libraries(${ROSLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${ROSLOG_TESTS} PRIVATE MODE_ROSLOG)
-        target_compile_options(${ROSLOG_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${ROSLOG_TESTS} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         ##### Default Tests #####
         set(DEFAULT_TESTS "test_default")
@@ -155,7 +162,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${DEFAULT_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/default)
         target_link_libraries(${DEFAULT_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${DEFAULT_TESTS} PRIVATE MODE_DEFAULT)
-        target_compile_options(${DEFAULT_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${DEFAULT_TESTS} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         ##### Nolog Tests #####
         set(NOLOG_TESTS "test_nolog")
@@ -173,7 +180,7 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         target_include_directories(${NOLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/nolog)
         target_link_libraries(${NOLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${NOLOG_TESTS} PRIVATE MODE_NOLOG)
-        target_compile_options(${NOLOG_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+        target_compile_options(${NOLOG_TESTS} PRIVATE ${LPP_TEST_CXX_FLAGS})
 
         add_custom_target(coverage
                 COMMAND mkdir coverage && cd coverage && gcovr -r ${CMAKE_SOURCE_DIR} --html --html-details -o coverage.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,9 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/glog/test_glog_vlog.cc)
 
         target_include_directories(${GLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/glog)
-        target_link_libraries(${GLOG_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${GLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${GLOG_TESTS} PRIVATE MODE_GLOG)
-        target_compile_options(${GLOG_TESTS} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${GLOG_TESTS} PRIVATE ${CMAKE_CXX_FLAGS} "-fprofile-arcs" "-ftest-coverage")
 
         ##### Log++ Tests #####
         set(LPP_TESTS "test_lpp")
@@ -101,9 +101,9 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/lpp/test_lpp_vlog.cc)
 
         target_include_directories(${LPP_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/lpp)
-        target_link_libraries(${LPP_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${LPP_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${LPP_TESTS} PRIVATE MODE_LPP)
-        target_compile_options(${LPP_TESTS} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${LPP_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
 
         ##### Log++ Custom Output Tests #####
         set(LPP_TESTS_CUSTOM "test_lpp_custom")
@@ -118,9 +118,9 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/lpp/custom/test_lpp_custom_vlog.cc)
 
         target_include_directories(${LPP_TESTS_CUSTOM} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/lpp)
-        target_link_libraries(${LPP_TESTS_CUSTOM} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${LPP_TESTS_CUSTOM} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${LPP_TESTS_CUSTOM} PRIVATE MODE_LPP)
-        target_compile_options(${LPP_TESTS_CUSTOM} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${LPP_TESTS_CUSTOM} PRIVATE "-fprofile-arcs" "-ftest-coverage")
 
         ##### Roslog Tests #####
         set(ROSLOG_TESTS "test_roslog")
@@ -134,9 +134,9 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/roslog/test_roslog_vlog.cc)
 
         target_include_directories(${ROSLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/roslog)
-        target_link_libraries(${ROSLOG_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${ROSLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${ROSLOG_TESTS} PRIVATE MODE_ROSLOG)
-        target_compile_options(${ROSLOG_TESTS} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${ROSLOG_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
 
         ##### Default Tests #####
         set(DEFAULT_TESTS "test_default")
@@ -153,9 +153,9 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
                 test/default/test_severity_conversions.cc)
 
         target_include_directories(${DEFAULT_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/default)
-        target_link_libraries(${DEFAULT_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${DEFAULT_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${DEFAULT_TESTS} PRIVATE MODE_DEFAULT)
-        target_compile_options(${DEFAULT_TESTS} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${DEFAULT_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
 
         ##### Nolog Tests #####
         set(NOLOG_TESTS "test_nolog")
@@ -171,7 +171,13 @@ if (GLOG_FOUND AND catkin_FOUND AND LPP_BUILD_TESTS)
         )
 
         target_include_directories(${NOLOG_TESTS} PRIVATE ${LPP_INCLUDE_DIRECTORIES} test/nolog)
-        target_link_libraries(${NOLOG_TESTS} glog gtest ${catkin_LIBRARIES})
+        target_link_libraries(${NOLOG_TESTS} glog gtest ${catkin_LIBRARIES} gcov)
         target_compile_definitions(${NOLOG_TESTS} PRIVATE MODE_NOLOG)
-        target_compile_options(${NOLOG_TESTS} PRIVATE "-fcompare-debug-second")
+        target_compile_options(${NOLOG_TESTS} PRIVATE "-fprofile-arcs" "-ftest-coverage")
+
+        add_custom_target(coverage
+                COMMAND mkdir coverage && cd coverage && gcovr -r ${CMAKE_SOURCE_DIR} --html --html-details -o coverage.html
+                COMMENT "Generating coverage report"
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
 endif ()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Log++ Logging framework
+[![lpp](https://github.com/ethz-asl/lpp/actions/workflows/cpp_ubuntu20_04.yml/badge.svg)](https://github.com/ethz-asl/lpp/actions/workflows/cpp_ubuntu20_04.yml)
 
+[Latest Code Coverage Report](https://ethz-asl.github.io/lpp/coverage.html) (master branch)
 
 ![](docs/Log++.svg)
 ***


### PR DESCRIPTION
# Features
### Code Coverage
- Added code coverage for unittests
- Added job to print code coverage
- Upload coverage report to github pages (Only on master branch)
- Added link to most recent coverage report in `README.md`
- Added `ENABLE_COVERAGE` switch in `CMakeLists.txt`

To suppress some warnings the `-fcompare-debug-second` compiler flag is used in lpp. This can not be used in combination with the  `-ftest-coverage` to generate a coverage report because some `.gcno` which are required to generate the coverage report are not generated.

From the GCC docs (https://gcc.gnu.org/onlinedocs/gcc-9.4.0/gcc/Developer-Options.html):

> This option is implicitly passed to the compiler for the second compilation requested by -fcompare-debug, along with options to silence warnings, and omitting other options that would cause the compiler to produce output to files or to standard output as a side effect

(This took me only half a day to figure out :sweat_smile:)

### Other
- Added support for `gcc-11`
- Added CI badge in `README.md`