### PR TITLE
Improve compile time

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt install -y gcovr
 
       - name: Build lpp
-        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
+        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 -DLPP_BUILD_TESTS=1 && make
         working-directory: catkin_ws/src/lpp
         shell: bash
 

--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -39,7 +39,7 @@ jobs:
       run: sudo apt install -y libgoogle-glog-dev
 
     - name: Build lpp
-      run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && catkin build -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} lpp && source ${GITHUB_WORKSPACE}/catkin_ws/devel/setup.bash
+      run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && catkin build -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} -DLPP_BUILD_TESTS=1 lpp && source ${GITHUB_WORKSPACE}/catkin_ws/devel/setup.bash
       working-directory: catkin_ws
       shell: bash
 

--- a/.github/workflows/deploy_coverage_report.yml
+++ b/.github/workflows/deploy_coverage_report.yml
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt install -y gcovr
 
       - name: Build lpp
-        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 && make
+        run: source /opt/ros/${{ matrix.rosdistro }}/setup.bash && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE="Debug" -DENABLE_COVERAGE=1 -DLPP_BUILD_TESTS=1 && make
         working-directory: catkin_ws/src/lpp
         shell: bash
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(lpp)
 
-# Don't build tests when using as a submodule
-if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
-        set(LPP_BUILD_TESTS 1)
-endif ()
-
 if (ENABLE_COVERAGE)
         set(LPP_TEST_CXX_FLAGS ${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage)
         message(STATUS "Coverage enabled")

--- a/README.md
+++ b/README.md
@@ -224,14 +224,25 @@ int main(int argc, char **argv) {
 | First N occurrences            | LOG_FIRST(I, n, str) | LOG_FIRST_N(INFO, n) << str          | ROS_INFO_ONCE(str) (only 1) |
 | Log to std::vector\<string>    | -                    | LOG_STRING(INFO, &vec) << str        | -                           |
 
-## TODOs
+## The following features are currently not supported (Feel free to contribute)
 - Implement ROS_INFO_NAMED() etc.
+- ROS2 support
 
-# Testing
+# Contributions
+The following information should be considered when contributing to Log++.
 
-- All modes (default, glog, lpp, roslog) have a separate test suite
-- All severity levels (Debug, Info, Warning, Error, Fatal)
-- All logging methods (Default, Conditional, Occasional, Timed, First N occurrences)
+## Build Unittests
+Unittests can be built by setting the `LPP_BUILD_TESTS` flag.
+If building with catkin, the tests can be built with the following command:
+
+```shell
+$ catkin build lpp -DLPP_BUILD_TESTS=1
+```
+
+## Unittests
+- All modes (default, glog, lpp, roslog, nolog) have a separate test suite. All tests should run with each mode.
+- Test all severity levels (Debug, Info, Warning, Error, Fatal)
+- Test if the functionality of a logging function works, not only the logging format (Default, Conditional, Occasional, Timed, First N occurrences)
 - Tests must run in debug mode in order to test debug log output
 
 Naming Convention:


### PR DESCRIPTION
Only build unit tests if `LPP_BUILD_TESTS=1` and updated `README.md`. This speeds up compilation with `catkin build` by ~10X.