### PR TITLE
Fix warnings in Findglog.cmake

### DIFF
--- a/cmake/Findglog.cmake
+++ b/cmake/Findglog.cmake
@@ -2,9 +2,7 @@ if(NOT COMMAND feature_summary)
     include(FeatureSummary)
 endif()
 
-if(NOT PKG_CONFIG_FOUND)
-    include(FindPkgConfig)
-endif()
+find_package(PkgConfig QUIET)
 
 if(NOT DEFINED GLOG_ROOT)
     set(GLOG_ROOT /usr /usr/local)
@@ -58,7 +56,7 @@ endmacro()
 _find_glog_libraries(GLOG_LIBRARIES libglog.so)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GLOG DEFAULT_MSG GLOG_LIBRARIES)
+find_package_handle_standard_args(glog DEFAULT_MSG GLOG_LIBRARIES)
 
 if(GLOG_FOUND)
     message(STATUS "glog library found at ${GLOG_LIBRARIES}")


### PR DESCRIPTION
Fix CMake warnings when using recent versions of cmake on ubuntu 20.04 caused by calling `find_package_handle_standard_args()` in `Findglog.cmake` for glog and PkgConfig

```bash
CMake Warning (dev) at /opt/clion-2023.1.4/bin/cmake/linux/x64/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (glog).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
```