### PR TITLE
C++23 

### DIFF
--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -43,6 +43,9 @@ jobs:
             cxx: '23'
           - gcc: '10'
             cxx: '23'
+          # Exclude all combinations of CXX 23 with Ubuntu 20.04
+          - ubuntu: '20.04'
+            cxx: '23'
     container:
       image: omavteam/ubuntu-omav-ros:ros-ros-base-${{ matrix.ubuntu }}
       credentials:

--- a/.github/workflows/cpp_ubuntu20_04.yml
+++ b/.github/workflows/cpp_ubuntu20_04.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         gcc: [ '8', '9', '10', '11', '12', '13' ]
-        cxx: [ '11', '14', '17', '20' ]
+        cxx: [ '11', '14', '17', '20', '23' ]
         ubuntu: [ '20.04', '22.04', '24.04']
         exclude:
           # Exclude GCC 8 on unsupported Ubuntu versions
@@ -36,6 +36,13 @@ jobs:
             cxx: '11'
           - ubuntu: '24.04'
             cxx: '14'
+          # Exclude all combinations of CXX 23 with GCC 8, 9, or 10
+          - gcc: '8'
+            cxx: '23'
+          - gcc: '9'
+            cxx: '23'
+          - gcc: '10'
+            cxx: '23'
     container:
       image: omavteam/ubuntu-omav-ros:ros-ros-base-${{ matrix.ubuntu }}
       credentials:


### PR DESCRIPTION
- Add `C++23` support for GCC 11 or higher (only on ubuntu 22+ as cmake is too old on previous versions)