### PR TITLE
Set include dir path for easier cmake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,25 +66,37 @@ if (catkin_FOUND)
                 )
 endif ()
 
-if (SKBUILD)
+if(SKBUILD)
         include(CMakePackageConfigHelpers)
 
-        configure_package_config_file(cmake/lppConfig.cmake.in
+        configure_package_config_file(
+                cmake/lppConfig.cmake.in
                 ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake
-                INSTALL_DESTINATION lpp/cmake/lpp)
+                INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
+        )
 
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
-                DESTINATION lpp/include/lpp)
-        install(TARGETS lpp EXPORT lppTargets)
+        install(FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
+                DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lpp
+        )
+
+        install(TARGETS lpp
+                EXPORT lppTargets
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+
         install(EXPORT lppTargets
                 FILE lppTargets.cmake
                 NAMESPACE lpp::
-                DESTINATION lpp/cmake/lpp)
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
+        )
 
-
-
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake DESTINATION lpp/cmake/lpp)
-endif ()
+        install(FILES
+                ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
+        )
+endif()
 
 if (GLOG_FOUND)
         target_link_libraries(lpp_demo glog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,6 @@ endif()
 find_package(glog)
 if (SKBUILD)
         message(STATUS "SKBUILD detected: skipping catkin integration")
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
-                DESTINATION lpp/include)
 else ()
         find_package(catkin REQUIRED COMPONENTS roscpp)
 endif ()
@@ -66,6 +64,26 @@ if (catkin_FOUND)
                 LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
                 RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
                 )
+endif ()
+
+if (SKBUILD)
+        include(CMakePackageConfigHelpers)
+
+        configure_package_config_file(cmake/lppConfig.cmake.in
+                ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake
+                INSTALL_DESTINATION lpp/cmake/lpp)
+
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
+                DESTINATION lpp/include/lpp)
+        install(TARGETS lpp EXPORT lppTargets)
+        install(EXPORT lppTargets
+                FILE lppTargets.cmake
+                NAMESPACE lpp::
+                DESTINATION lpp/cmake/lpp)
+
+
+
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake DESTINATION lpp/cmake/lpp)
 endif ()
 
 if (GLOG_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,37 +66,25 @@ if (catkin_FOUND)
                 )
 endif ()
 
-if(SKBUILD)
+if (SKBUILD)
         include(CMakePackageConfigHelpers)
 
-        configure_package_config_file(
-                cmake/lppConfig.cmake.in
+        configure_package_config_file(cmake/lppConfig.cmake.in
                 ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake
-                INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
-        )
+                INSTALL_DESTINATION lpp/cmake/lpp)
 
-        install(FILES
-                ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
-                DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lpp
-        )
-
-        install(TARGETS lpp
-                EXPORT lppTargets
-                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
-
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/log++.h
+                DESTINATION lpp/include/lpp)
+        install(TARGETS lpp EXPORT lppTargets)
         install(EXPORT lppTargets
                 FILE lppTargets.cmake
                 NAMESPACE lpp::
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
-        )
+                DESTINATION lpp/cmake/lpp)
 
-        install(FILES
-                ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lpp
-        )
-endif()
+
+
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake DESTINATION lpp/cmake/lpp)
+endif ()
 
 if (GLOG_FOUND)
         target_link_libraries(lpp_demo glog)

--- a/cmake/lppConfig.cmake.in
+++ b/cmake/lppConfig.cmake.in
@@ -1,2 +1,4 @@
 @PACKAGE_INIT@
+
+set_and_check(lpp_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/lpp/include/lpp")
 include("${CMAKE_CURRENT_LIST_DIR}/lppTargets.cmake")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 
+[project.entry-points."cmake.prefix"]
+lpp = "lpp.cmake"
+
 [project.urls]
 Homepage = "https://github.com/ethz-asl/lpp"
 Repository = "https://github.com/ethz-asl/lpp"


### PR DESCRIPTION
This PR exposes the include dir path of lpp through `find_package(lpp)` for easier cmake integration in packages that use lpp as a dependency when using pip.

```cmake
find_package(Python COMPONENTS Interpreter REQUIRED)

execute_process(
  COMMAND "${Python_EXECUTABLE}" -c "import pathlib, lpp; print(pathlib.Path(lpp.__file__).resolve().parent / 'include')"
  OUTPUT_VARIABLE LPP_INCLUDE_DIR
  OUTPUT_STRIP_TRAILING_WHITESPACE
  RESULT_VARIABLE LPP_DISCOVERY_RC
  ERROR_VARIABLE LPP_DISCOVERY_ERR
)

if(NOT LPP_DISCOVERY_RC EQUAL 0 OR NOT EXISTS "${LPP_INCLUDE_DIR}/log++.h")
  message(FATAL_ERROR
    "Failed to resolve lpp headers via Python import path. "
    "stderr: ${LPP_DISCOVERY_ERR}"
  )
endif()
set(LPP_INCLUDE_DIR "${LPP_INCLUDE_DIR}" CACHE PATH "Path to lpp headers" FORCE)
```
can be replaced with:
```cmake
find_package(lpp REQUIRED)
```