### PR TITLE
Add Python bindings for lpp

### DIFF
--- a/.github/workflows/python_install.yml
+++ b/.github/workflows/python_install.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Install lpp
         run: uv sync --python ${{ matrix.python-version }}
+
+      - name: Run Python tests
+        run: uv run --python ${{ matrix.python-version }} --with pytest pytest test/python

--- a/.github/workflows/python_install.yml
+++ b/.github/workflows/python_install.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         ubuntu: ["22.04", "24.04"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     container:
       image: omavteam/ubuntu-omav:${{ matrix.ubuntu }}
       credentials:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ cmake-build*
 *.exe
 *.out
 *.app
+
+**/__pycache__/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(lpp)
 
+option(LPP_BUILD_PYTHON_BINDINGS "Build lpp Python bindings" OFF)
+
 if (ENABLE_COVERAGE)
         set(LPP_TEST_CXX_FLAGS ${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage)
         message(STATUS "Coverage enabled")
@@ -90,6 +92,19 @@ if (SKBUILD)
 
 
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lppConfig.cmake DESTINATION share/lpp/cmake)
+
+        if (LPP_BUILD_PYTHON_BINDINGS)
+                find_package(Python COMPONENTS Interpreter Development REQUIRED)
+                find_package(nanobind CONFIG REQUIRED)
+
+                nanobind_add_module(_lpp python/lpp_bindings.cc)
+                target_include_directories(_lpp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+                install(TARGETS _lpp LIBRARY DESTINATION lpp)
+        endif ()
+endif ()
+
+if (LPP_BUILD_PYTHON_BINDINGS AND NOT SKBUILD)
+        message(FATAL_ERROR "LPP_BUILD_PYTHON_BINDINGS is only supported when building with scikit-build-core")
 endif ()
 
 if (GLOG_FOUND)

--- a/README.md
+++ b/README.md
@@ -326,12 +326,10 @@ If building with catkin, the tests can be built with the following command:
 $ catkin build lpp -DLPP_BUILD_TESTS=1
 ```
 
-Python binding tests are written with pytest. Build a wheel and run the tests
-against that wheel:
+Python binding tests are written with pytest. Run with:
 
 ```shell
-$ uv build --out-dir /tmp/lpp-dist
-$ uv run --no-project --with pytest --with /tmp/lpp-dist/<wheel-name>.whl pytest --rootdir=/tmp test/python
+uv run --with pytest pytest test/python
 ```
 
 ## Unittests

--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ $ uv build
 - **MODE_LPP** Log++ Logging output.
 - **MODE_GLOG:** Google Logging output. Calls abort() if it logs a fatal error.
 - **MODE_ROSLOG:** ROS Logging output.
-- **MODE_SYSD:** systemd journal output.
+- **MODE_SYSD:** systemd journal output. Logs can be viewed with
+  `journalctl -t <identifier>`, or followed live with
+  `journalctl -f -t <identifier>`. The identifier is the systemd journal
+  `SYSLOG_IDENTIFIER` field; by default it is the executable name passed to
+  `LOG_INIT(argv[0])`, with any path stripped.
 - **MODE_DEFAULT:** Disables Logging standardization. Messages are logged according to their framework.
 - **MODE_NOLOG:** Disables Logging completely. Useful for unittests or in some cases for release builds.
 
@@ -249,6 +253,9 @@ logger.critical("cannot continue")
 
 - `LogMode.MODE_LPP`: Log++ stdout-style output. This mode also supports a Python callback.
 - `LogMode.MODE_SYSD`: systemd journal output. Pass `identifier="my-service"` to set `SYSLOG_IDENTIFIER`.
+  Logs can be viewed with `journalctl -t my-service`, or followed live with
+  `journalctl -f -t my-service`. If no identifier is provided, the Python
+  binding uses the process basename from `sys.argv[0]`.
 - `LogMode.MODE_NOLOG`: accepts log calls and emits nothing.
 - `LogMode.MODE_DEFAULT`: uses Log++ stdout-style output for the Python handler.
 - `LogMode.MODE_GLOG` and `LogMode.MODE_ROSLOG`: enum values are exported, but construction raises `RuntimeError` unless these backends are implemented for Python.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 
 - Framework to standardize ros and glog output at compile time.
 - Uses ros/glog's native log calls depending on selected mode.
+- Optional Python bindings with a method-based logger API.
 - Customize log output
 - All log calls are thread-safe.
 - Lightweight with performance in mind
-- Header only
+- Header only for C++
 - GCC 8 or later required
 - Recommended to use with C++17/C++20, but also works with C++11/C++14.
 
@@ -77,7 +78,7 @@ I0929 11:57:50.238536 1360823 main.cpp:8] Foo: 5
 - a project:
 
 ```cmake
-# Valid modes are: MODE_LPP MODE_GLOG MODE_ROSLOG MODE_DEFAULT
+# Valid modes are: MODE_LPP MODE_GLOG MODE_ROSLOG MODE_SYSD MODE_DEFAULT MODE_NOLOG
 # Use add_definitions(-DMODE_LPP) if cmake version <= 3.11
 
 add_compile_definitions(MODE_LPP)
@@ -128,6 +129,20 @@ $ git clone git@github.com:ethz-asl/lpp.git
 $ catkin build lpp
 ```
 
+### Option 4: Install the Python package
+The Python bindings are built only through scikit-build. Normal CMake and catkin
+builds do not require Python or nanobind.
+
+```shell
+$ uv pip install .
+```
+
+or build a wheel:
+
+```shell
+$ uv build
+```
+
 # Usage
 
 ## Modes
@@ -135,6 +150,7 @@ $ catkin build lpp
 - **MODE_LPP** Log++ Logging output.
 - **MODE_GLOG:** Google Logging output. Calls abort() if it logs a fatal error.
 - **MODE_ROSLOG:** ROS Logging output.
+- **MODE_SYSD:** systemd journal output.
 - **MODE_DEFAULT:** Disables Logging standardization. Messages are logged according to their framework.
 - **MODE_NOLOG:** Disables Logging completely. Useful for unittests or in some cases for release builds.
 
@@ -165,7 +181,7 @@ Log++ provides its own logging functions, if you want to use Log++ as the base l
 ```c++
 int foo = 1;
 int bar = 3;
-LOG(I, "Values: " << foo " " << bar);
+LOG(I, "Values: " << foo << " " << bar);
 ```
 
 ### Conditional logging
@@ -173,7 +189,7 @@ LOG(I, "Values: " << foo " " << bar);
 ```c++
 int foo = 1;
 int bar = 3;
-LOG(I, foo != bar, "Values: " << foo << " " << bar)
+LOG(I, foo != bar, "Values: " << foo << " " << bar);
 ```
 
 ### Occasional logging
@@ -213,6 +229,76 @@ int main(int argc, char **argv) {
 }
 ```
 
+## Python bindings
+
+The Python API provides a low-boilerplate `Logger()` helper for short scripts.
+It returns a standard `logging.Logger` configured with an `LppHandler` and
+`logging.INFO` level.
+
+```python
+from lpp import LogMode, Logger
+
+logger = Logger("foo", LogMode.MODE_LPP)
+
+logger.info("started")
+logger.warning("many retries")
+logger.critical("cannot continue")
+```
+
+### Python modes
+
+- `LogMode.MODE_LPP`: Log++ stdout-style output. This mode also supports a Python callback.
+- `LogMode.MODE_SYSD`: systemd journal output. Pass `identifier="my-service"` to set `SYSLOG_IDENTIFIER`.
+- `LogMode.MODE_NOLOG`: accepts log calls and emits nothing.
+- `LogMode.MODE_DEFAULT`: uses Log++ stdout-style output for the Python handler.
+- `LogMode.MODE_GLOG` and `LogMode.MODE_ROSLOG`: enum values are exported, but construction raises `RuntimeError` unless these backends are implemented for Python.
+
+```python
+import logging
+from lpp import LogMode, Logger
+
+logger = Logger("my-service", LogMode.MODE_SYSD, identifier="my-service")
+logger.error("failed to connect")
+```
+
+### Python logging methods
+
+Use the standard Python logging API:
+
+```python
+logger.debug("details")
+logger.info("ready")
+logger.info("value=%s", value)
+logger.warning("retrying")
+logger.error("failed")
+logger.critical("cannot continue")
+```
+
+`critical()` maps to Log++ fatal severity. Python logging handles formatting,
+filters, levels, propagation, and handlers before the record reaches `LppHandler`.
+Log++ policy helpers such as `LOG_EVERY` are intentionally not part of the
+Python API; use standard `logging.Filter` patterns for Python-side filtering or
+throttling.
+
+For advanced logging setup, attach `LppHandler` manually:
+
+```python
+import logging
+from lpp import LogMode, LppHandler
+
+logger = logging.getLogger("foo")
+logger.addHandler(LppHandler(LogMode.MODE_LPP))
+logger.setLevel(logging.INFO)
+```
+
+`MODE_LPP` can also route output through a callback, which is useful for tests:
+
+```python
+events = []
+logger = Logger("test", callback=lambda severity, message: events.append((severity, message)))
+logger.warning("captured")
+```
+
 ## Overview of logging methods
 
 | Method                         | Log++                | Glog                                 | ROS                         | 
@@ -240,11 +326,20 @@ If building with catkin, the tests can be built with the following command:
 $ catkin build lpp -DLPP_BUILD_TESTS=1
 ```
 
+Python binding tests are written with pytest. Build a wheel and run the tests
+against that wheel:
+
+```shell
+$ uv build --out-dir /tmp/lpp-dist
+$ uv run --no-project --with pytest --with /tmp/lpp-dist/<wheel-name>.whl pytest --rootdir=/tmp test/python
+```
+
 ## Unittests
 - All modes (default, glog, lpp, roslog, nolog) have a separate test suite. All tests should run with each mode.
 - Test all severity levels (Debug, Info, Warning, Error, Fatal)
 - Test if the functionality of a logging function works, not only the logging format (Default, Conditional, Occasional, Timed, First N occurrences)
 - Tests must run in debug mode in order to test debug log output
+- Python tests mirror the C++ behavior groups for the method-based binding API.
 
 Naming Convention:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.5.1"]
+requires = ["scikit-build-core>=0.5.1", "nanobind"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "lpp"
-version = "1.0.4"
+version = "1.1.0"
 description = "Log++ logging framework header-only library"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -28,3 +28,6 @@ Repository = "https://github.com/ethz-asl/lpp"
 [tool.scikit-build]
 cmake.source-dir = "."
 wheel.packages = ["python/lpp"]
+
+[tool.scikit-build.cmake.define]
+LPP_BUILD_PYTHON_BINDINGS = "ON"

--- a/python/lpp/__init__.py
+++ b/python/lpp/__init__.py
@@ -1,2 +1,5 @@
-"""Python package marker for lpp."""
+"""Python bindings for Log++."""
 
+from ._lpp import LogMode, Logger, LppSeverity
+
+__all__ = ["LogMode", "Logger", "LppSeverity"]

--- a/python/lpp/__init__.py
+++ b/python/lpp/__init__.py
@@ -1,5 +1,6 @@
 """Python bindings for Log++."""
 
-from ._lpp import LogMode, Logger, LppSeverity
+from ._lpp import LogMode, LppSeverity
+from .handler import Logger, LppHandler
 
-__all__ = ["LogMode", "Logger", "LppSeverity"]
+__all__ = ["LogMode", "Logger", "LppHandler", "LppSeverity"]

--- a/python/lpp/handler.py
+++ b/python/lpp/handler.py
@@ -1,0 +1,73 @@
+"""Python logging integration for Log++."""
+
+import logging
+
+from ._lpp import LogMode, LppSeverity, _LppEmitter
+
+
+def _severity_from_level(levelno):
+    if levelno >= logging.CRITICAL:
+        return LppSeverity.F
+    if levelno >= logging.ERROR:
+        return LppSeverity.E
+    if levelno >= logging.WARNING:
+        return LppSeverity.W
+    if levelno >= logging.INFO:
+        return LppSeverity.I
+    return LppSeverity.D
+
+
+class LppHandler(logging.Handler):
+    """Logging handler that forwards Python log records to Log++."""
+
+    def __init__(
+        self,
+        mode=LogMode.MODE_LPP,
+        identifier=None,
+        level=logging.NOTSET,
+        callback=None,
+        sysd_sender=None,
+    ):
+        super().__init__(level)
+        self._emitter = _LppEmitter(
+            mode=mode,
+            identifier=identifier,
+            callback=callback,
+            sysd_sender=sysd_sender,
+        )
+
+    def emit(self, record):
+        try:
+            self._emitter.emit(_severity_from_level(record.levelno), self.format(record))
+        except Exception:
+            self.handleError(record)
+
+
+def Logger(
+    name,
+    mode=LogMode.MODE_LPP,
+    level=logging.INFO,
+    identifier=None,
+    callback=None,
+    sysd_sender=None,
+    propagate=False,
+):
+    """Return a standard logger configured with an LppHandler."""
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = propagate
+
+    for handler in list(logger.handlers):
+        if isinstance(handler, LppHandler) and getattr(handler, "_installed_by_lpp_logger", False):
+            logger.removeHandler(handler)
+
+    handler = LppHandler(
+        mode=mode,
+        identifier=identifier,
+        callback=callback,
+        sysd_sender=sysd_sender,
+    )
+    handler._installed_by_lpp_logger = True
+    logger.addHandler(handler)
+    return logger

--- a/python/lpp/handler.py
+++ b/python/lpp/handler.py
@@ -1,6 +1,8 @@
 """Python logging integration for Log++."""
 
 import logging
+import os
+import sys
 
 from ._lpp import LogMode, LppSeverity, _LppEmitter
 
@@ -17,6 +19,17 @@ def _severity_from_level(levelno):
     return LppSeverity.D
 
 
+def _default_sysd_identifier():
+    argv0 = sys.argv[0] if sys.argv else ""
+    return os.path.basename(argv0)
+
+
+def _resolve_identifier(mode, identifier):
+    if mode == LogMode.MODE_SYSD and identifier is None:
+        return _default_sysd_identifier()
+    return identifier
+
+
 class LppHandler(logging.Handler):
     """Logging handler that forwards Python log records to Log++."""
 
@@ -31,7 +44,7 @@ class LppHandler(logging.Handler):
         super().__init__(level)
         self._emitter = _LppEmitter(
             mode=mode,
-            identifier=identifier,
+            identifier=_resolve_identifier(mode, identifier),
             callback=callback,
             sysd_sender=sysd_sender,
         )

--- a/python/lpp_bindings.cc
+++ b/python/lpp_bindings.cc
@@ -5,13 +5,10 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
-#include <optional>
 #include <string>
-#include <unordered_map>
 
 #if defined(__has_include)
 #if __has_include(<sys/socket.h>) && __has_include(<sys/un.h>) && __has_include(<syslog.h>) && __has_include(<unistd.h>)
@@ -75,50 +72,6 @@ LppSeverity toLppSeverity(BaseSeverity severity) {
 
 std::string objectToString(const nb::object &object) {
   return nb::cast<std::string>(nb::str(object));
-}
-
-std::string callerKey(const std::string &policy_name) {
-  PyFrameObject *frame = PyEval_GetFrame();
-  if (frame == nullptr) {
-    return policy_name + ":<unknown>:0";
-  }
-
-  const int line = PyFrame_GetLineNumber(frame);
-  PyObject *code = reinterpret_cast<PyObject *>(PyFrame_GetCode(frame));
-  if (code == nullptr) {
-    return policy_name + ":<unknown>:" + std::to_string(line);
-  }
-
-  PyObject *filename_obj = PyObject_GetAttrString(code, "co_filename");
-  std::string filename = "<unknown>";
-  if (filename_obj != nullptr) {
-    const char *filename_chars = PyUnicode_AsUTF8(filename_obj);
-    if (filename_chars != nullptr) {
-      filename = filename_chars;
-    }
-    Py_DECREF(filename_obj);
-  } else {
-    PyErr_Clear();
-  }
-
-  Py_DECREF(code);
-  return policy_name + ":" + filename + ":" + std::to_string(line);
-}
-
-std::string policyKey(const nb::object &key, const std::string &policy_name) {
-  if (key.ptr() != Py_None) {
-    return nb::cast<std::string>(key);
-  }
-  return callerKey(policy_name);
-}
-
-nb::object formatMessage(const std::string &format, const nb::args &args) {
-  nb::str py_format(format.c_str());
-  PyObject *formatted = PyNumber_Remainder(py_format.ptr(), args.ptr());
-  if (formatted == nullptr) {
-    throw nb::python_error();
-  }
-  return nb::steal(formatted);
 }
 
 #ifdef LPP_PY_SYSD_SUPPORTED
@@ -196,13 +149,12 @@ void sendToJournal(BaseSeverity severity, const std::string &message, const std:
 
 }  // namespace
 
-class Logger {
+class LppEmitter {
  public:
-  Logger(LogMode mode, nb::object identifier, nb::object callback, int verbosity, nb::object sysd_sender)
+  LppEmitter(LogMode mode, nb::object identifier, nb::object callback, nb::object sysd_sender)
       : mode_(mode),
         identifier_(identifier.ptr() == Py_None ? "" : nb::cast<std::string>(identifier)),
         callback_(std::move(callback)),
-        verbosity_(verbosity),
         sysd_sender_(std::move(sysd_sender)) {
     if (mode_ == LogMode::MODE_GLOG) {
       throw std::runtime_error("MODE_GLOG is not available in the Python bindings");
@@ -217,108 +169,18 @@ class Logger {
 #endif
   }
 
-  void log(LppSeverity severity, const nb::object &message) {
-    emit(lpp::internal::toBase(severity), objectToString(message));
-  }
-
-  void logIf(LppSeverity severity, bool condition, const nb::object &message) {
-    if (condition) {
-      log(severity, message);
-    }
-  }
-
-  void logEvery(LppSeverity severity, unsigned int n, const nb::object &message, const nb::object &key) {
-    validateCount(n);
-    const std::string resolved_key = policyKey(key, "every");
-    auto &counter = every_counters_[resolved_key];
-    const bool should_log = counter % n == 0U;
-    ++counter;
-    if (should_log) {
-      log(severity, message);
-    }
-  }
-
-  void logFirst(LppSeverity severity, unsigned int n, const nb::object &message, const nb::object &key) {
-    const std::string resolved_key = policyKey(key, "first");
-    auto &counter = first_counters_[resolved_key];
-    if (counter < n) {
-      ++counter;
-      log(severity, message);
-    }
-  }
-
-  void logTimed(LppSeverity severity, float seconds, const nb::object &message, const nb::object &key) {
-    if (seconds < 0.0F) {
-      throw std::invalid_argument("seconds must be non-negative");
-    }
-
-    const std::string resolved_key = policyKey(key, "timed");
-    const auto now = std::chrono::steady_clock::now();
-    auto it = timed_last_log_.find(resolved_key);
-    if (it == timed_last_log_.end() ||
-        now >= it->second + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                              std::chrono::duration<float>(seconds))) {
-      timed_last_log_[resolved_key] = now;
-      log(severity, message);
-    }
-  }
-
-  void logString(LppSeverity severity, const nb::object &message, const nb::object &sink) {
-    const std::string string_message = objectToString(message);
-    if (sink.ptr() != Py_None) {
-      sink.attr("append")(string_message);
-      return;
-    }
-    emit(lpp::internal::toBase(severity), string_message);
-  }
-
-  void logFormat(LppSeverity severity, const std::string &format, const nb::args &args) {
-    log(severity, formatMessage(format, args));
-  }
-
-  void vlog(LppSeverity severity, int verbose_level, const nb::object &message) {
-    if (verbosity_ >= verbose_level) {
-      log(severity, message);
-    }
-  }
-
-  void vlogIf(LppSeverity severity, int verbose_level, bool condition, const nb::object &message) {
-    if (condition) {
-      vlog(severity, verbose_level, message);
-    }
-  }
-
-  void vlogEvery(LppSeverity severity, int verbose_level, unsigned int n, const nb::object &message, const nb::object &key) {
-    if (verbosity_ >= verbose_level) {
-      logEvery(severity, n, message, key);
-    }
-  }
-
-  void vlogIfEvery(LppSeverity severity,
-                   int verbose_level,
-                   bool condition,
-                   unsigned int n,
-                   const nb::object &message,
-                   const nb::object &key) {
-    if (condition) {
-      vlogEvery(severity, verbose_level, n, message, key);
-    }
+  void emit(LppSeverity severity, const nb::object &message) {
+    emitMessage(lpp::internal::toBase(severity), objectToString(message));
   }
 
  private:
-  static void validateCount(unsigned int n) {
-    if (n == 0U) {
-      throw std::invalid_argument("n must be greater than zero");
-    }
-  }
-
-  void emit(BaseSeverity severity, const std::string &message) {
+  void emitMessage(BaseSeverity severity, const std::string &message) {
     if (mode_ == LogMode::MODE_NOLOG) {
       return;
     }
 
     if (mode_ == LogMode::MODE_SYSD) {
-      emitSysd(severity, message);
+      emitSysdMessage(severity, message);
       return;
     }
 
@@ -330,7 +192,7 @@ class Logger {
     std::cout << severityPrefix(severity) << message << std::endl;
   }
 
-  void emitSysd(BaseSeverity severity, const std::string &message) {
+  void emitSysdMessage(BaseSeverity severity, const std::string &message) {
 #ifdef NDEBUG
     if (severity == BaseSeverity::DEBUG) {
       return;
@@ -348,11 +210,7 @@ class Logger {
   LogMode mode_;
   std::string identifier_;
   nb::object callback_;
-  int verbosity_;
   nb::object sysd_sender_;
-  std::unordered_map<std::string, unsigned int> every_counters_;
-  std::unordered_map<std::string, unsigned int> first_counters_;
-  std::unordered_map<std::string, std::chrono::steady_clock::time_point> timed_last_log_;
 };
 
 }  // namespace lpp::python
@@ -375,39 +233,11 @@ NB_MODULE(_lpp, m) {
       .value("MODE_GLOG", lpp::python::LogMode::MODE_GLOG)
       .value("MODE_ROSLOG", lpp::python::LogMode::MODE_ROSLOG);
 
-  nb::class_<lpp::python::Logger>(m, "Logger")
-      .def(nb::init<lpp::python::LogMode, nb::object, nb::object, int, nb::object>(),
+  nb::class_<lpp::python::LppEmitter>(m, "_LppEmitter")
+      .def(nb::init<lpp::python::LogMode, nb::object, nb::object, nb::object>(),
            "mode"_a = lpp::python::LogMode::MODE_LPP,
            "identifier"_a = nb::none(),
            "callback"_a = nb::none(),
-           "verbosity"_a = 0,
            "sysd_sender"_a = nb::none())
-      .def("log", &lpp::python::Logger::log, "severity"_a, "message"_a)
-      .def("log_if", &lpp::python::Logger::logIf, "severity"_a, "condition"_a, "message"_a)
-      .def("log_every", &lpp::python::Logger::logEvery, "severity"_a, "n"_a, "message"_a, "key"_a = nb::none())
-      .def("log_first", &lpp::python::Logger::logFirst, "severity"_a, "n"_a, "message"_a, "key"_a = nb::none())
-      .def("log_timed", &lpp::python::Logger::logTimed, "severity"_a, "seconds"_a, "message"_a, "key"_a = nb::none())
-      .def("log_string", &lpp::python::Logger::logString, "severity"_a, "message"_a, "sink"_a = nb::none())
-      .def("log_format",
-           [](lpp::python::Logger &self,
-              lpp::internal::LppSeverity severity,
-              const std::string &format,
-              const nb::args &args) { self.logFormat(severity, format, args); })
-      .def("vlog", &lpp::python::Logger::vlog, "severity"_a, "verbose_level"_a, "message"_a)
-      .def("vlog_if", &lpp::python::Logger::vlogIf, "severity"_a, "verbose_level"_a, "condition"_a, "message"_a)
-      .def("vlog_every",
-           &lpp::python::Logger::vlogEvery,
-           "severity"_a,
-           "verbose_level"_a,
-           "n"_a,
-           "message"_a,
-           "key"_a = nb::none())
-      .def("vlog_if_every",
-           &lpp::python::Logger::vlogIfEvery,
-           "severity"_a,
-           "verbose_level"_a,
-           "condition"_a,
-           "n"_a,
-           "message"_a,
-           "key"_a = nb::none());
+      .def("emit", &lpp::python::LppEmitter::emit, "severity"_a, "message"_a);
 }

--- a/python/lpp_bindings.cc
+++ b/python/lpp_bindings.cc
@@ -1,0 +1,413 @@
+#define MODE_NOLOG 1
+#include <log++.h>
+#undef MODE_NOLOG
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#if defined(__has_include)
+#if __has_include(<sys/socket.h>) && __has_include(<sys/un.h>) && __has_include(<syslog.h>) && __has_include(<unistd.h>)
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <syslog.h>
+#include <unistd.h>
+#define LPP_PY_SYSD_SUPPORTED
+#endif
+#endif
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace lpp::python {
+namespace {
+
+using BaseSeverity = lpp::internal::BaseSeverity;
+using LppSeverity = lpp::internal::LppSeverity;
+
+enum class LogMode {
+  MODE_LPP,
+  MODE_SYSD,
+  MODE_NOLOG,
+  MODE_DEFAULT,
+  MODE_GLOG,
+  MODE_ROSLOG
+};
+
+std::string severityPrefix(BaseSeverity severity) {
+  switch (severity) {
+    case BaseSeverity::DEBUG:
+      return "DEBUG ";
+    case BaseSeverity::INFO:
+      return "INFO  ";
+    case BaseSeverity::WARN:
+      return "WARN  ";
+    case BaseSeverity::ERROR:
+      return "ERROR ";
+    case BaseSeverity::FATAL:
+      return "FATAL ";
+  }
+  return "INFO  ";
+}
+
+LppSeverity toLppSeverity(BaseSeverity severity) {
+  switch (severity) {
+    case BaseSeverity::DEBUG:
+      return LppSeverity::D;
+    case BaseSeverity::INFO:
+      return LppSeverity::I;
+    case BaseSeverity::WARN:
+      return LppSeverity::W;
+    case BaseSeverity::ERROR:
+      return LppSeverity::E;
+    case BaseSeverity::FATAL:
+      return LppSeverity::F;
+  }
+  return LppSeverity::I;
+}
+
+std::string objectToString(const nb::object &object) {
+  return nb::cast<std::string>(nb::str(object));
+}
+
+std::string callerKey(const std::string &policy_name) {
+  PyFrameObject *frame = PyEval_GetFrame();
+  if (frame == nullptr) {
+    return policy_name + ":<unknown>:0";
+  }
+
+  const int line = PyFrame_GetLineNumber(frame);
+  PyObject *code = reinterpret_cast<PyObject *>(PyFrame_GetCode(frame));
+  if (code == nullptr) {
+    return policy_name + ":<unknown>:" + std::to_string(line);
+  }
+
+  PyObject *filename_obj = PyObject_GetAttrString(code, "co_filename");
+  std::string filename = "<unknown>";
+  if (filename_obj != nullptr) {
+    const char *filename_chars = PyUnicode_AsUTF8(filename_obj);
+    if (filename_chars != nullptr) {
+      filename = filename_chars;
+    }
+    Py_DECREF(filename_obj);
+  } else {
+    PyErr_Clear();
+  }
+
+  Py_DECREF(code);
+  return policy_name + ":" + filename + ":" + std::to_string(line);
+}
+
+std::string policyKey(const nb::object &key, const std::string &policy_name) {
+  if (key.ptr() != Py_None) {
+    return nb::cast<std::string>(key);
+  }
+  return callerKey(policy_name);
+}
+
+nb::object formatMessage(const std::string &format, const nb::args &args) {
+  nb::str py_format(format.c_str());
+  PyObject *formatted = PyNumber_Remainder(py_format.ptr(), args.ptr());
+  if (formatted == nullptr) {
+    throw nb::python_error();
+  }
+  return nb::steal(formatted);
+}
+
+#ifdef LPP_PY_SYSD_SUPPORTED
+int toSysdPriority(BaseSeverity severity) {
+  switch (severity) {
+    case BaseSeverity::DEBUG:
+      return LOG_DEBUG;
+    case BaseSeverity::INFO:
+      return LOG_INFO;
+    case BaseSeverity::WARN:
+      return LOG_WARNING;
+    case BaseSeverity::ERROR:
+      return LOG_ERR;
+    case BaseSeverity::FATAL:
+      return LOG_CRIT;
+  }
+  return LOG_INFO;
+}
+
+void appendLittleEndianUint64(std::string *payload, std::uint64_t value) {
+  for (unsigned int i = 0; i < sizeof(value); ++i) {
+    payload->push_back(static_cast<char>((value >> (i * 8U)) & 0xffU));
+  }
+}
+
+void appendJournalField(std::string *payload, const std::string &field, const std::string &value) {
+  if (value.find('\n') == std::string::npos) {
+    payload->append(field);
+    payload->push_back('=');
+    payload->append(value);
+    payload->push_back('\n');
+    return;
+  }
+
+  payload->append(field);
+  payload->push_back('\n');
+  appendLittleEndianUint64(payload, static_cast<std::uint64_t>(value.size()));
+  payload->append(value);
+  payload->push_back('\n');
+}
+
+std::string makeJournalPayload(BaseSeverity severity, const std::string &message, const std::string &identifier) {
+  std::string payload;
+  appendJournalField(&payload, "MESSAGE", message);
+  appendJournalField(&payload, "PRIORITY", std::to_string(toSysdPriority(severity)));
+  if (!identifier.empty()) {
+    appendJournalField(&payload, "SYSLOG_IDENTIFIER", identifier);
+  }
+  return payload;
+}
+
+void sendToJournal(BaseSeverity severity, const std::string &message, const std::string &identifier) {
+  constexpr const char *kJournalSocketPath = "/run/systemd/journal/socket";
+
+  const int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+  if (fd < 0) {
+    return;
+  }
+
+  const std::string payload = makeJournalPayload(severity, message, identifier);
+  sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, kJournalSocketPath, sizeof(addr.sun_path) - 1U);
+
+  int flags = MSG_DONTWAIT;
+#ifdef MSG_NOSIGNAL
+  flags |= MSG_NOSIGNAL;
+#endif
+
+  const auto addr_len = static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + std::strlen(kJournalSocketPath) + 1U);
+  (void) sendto(fd, payload.data(), payload.size(), flags, reinterpret_cast<sockaddr *>(&addr), addr_len);
+  (void) close(fd);
+}
+#endif
+
+}  // namespace
+
+class Logger {
+ public:
+  Logger(LogMode mode, nb::object identifier, nb::object callback, int verbosity, nb::object sysd_sender)
+      : mode_(mode),
+        identifier_(identifier.ptr() == Py_None ? "" : nb::cast<std::string>(identifier)),
+        callback_(std::move(callback)),
+        verbosity_(verbosity),
+        sysd_sender_(std::move(sysd_sender)) {
+    if (mode_ == LogMode::MODE_GLOG) {
+      throw std::runtime_error("MODE_GLOG is not available in the Python bindings");
+    }
+    if (mode_ == LogMode::MODE_ROSLOG) {
+      throw std::runtime_error("MODE_ROSLOG is not available in the Python bindings");
+    }
+#ifndef LPP_PY_SYSD_SUPPORTED
+    if (mode_ == LogMode::MODE_SYSD && sysd_sender_.ptr() == Py_None) {
+      throw std::runtime_error("MODE_SYSD is not supported on this platform without a sysd_sender callback");
+    }
+#endif
+  }
+
+  void log(LppSeverity severity, const nb::object &message) {
+    emit(lpp::internal::toBase(severity), objectToString(message));
+  }
+
+  void logIf(LppSeverity severity, bool condition, const nb::object &message) {
+    if (condition) {
+      log(severity, message);
+    }
+  }
+
+  void logEvery(LppSeverity severity, unsigned int n, const nb::object &message, const nb::object &key) {
+    validateCount(n);
+    const std::string resolved_key = policyKey(key, "every");
+    auto &counter = every_counters_[resolved_key];
+    const bool should_log = counter % n == 0U;
+    ++counter;
+    if (should_log) {
+      log(severity, message);
+    }
+  }
+
+  void logFirst(LppSeverity severity, unsigned int n, const nb::object &message, const nb::object &key) {
+    const std::string resolved_key = policyKey(key, "first");
+    auto &counter = first_counters_[resolved_key];
+    if (counter < n) {
+      ++counter;
+      log(severity, message);
+    }
+  }
+
+  void logTimed(LppSeverity severity, float seconds, const nb::object &message, const nb::object &key) {
+    if (seconds < 0.0F) {
+      throw std::invalid_argument("seconds must be non-negative");
+    }
+
+    const std::string resolved_key = policyKey(key, "timed");
+    const auto now = std::chrono::steady_clock::now();
+    auto it = timed_last_log_.find(resolved_key);
+    if (it == timed_last_log_.end() ||
+        now >= it->second + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                              std::chrono::duration<float>(seconds))) {
+      timed_last_log_[resolved_key] = now;
+      log(severity, message);
+    }
+  }
+
+  void logString(LppSeverity severity, const nb::object &message, const nb::object &sink) {
+    const std::string string_message = objectToString(message);
+    if (sink.ptr() != Py_None) {
+      sink.attr("append")(string_message);
+      return;
+    }
+    emit(lpp::internal::toBase(severity), string_message);
+  }
+
+  void logFormat(LppSeverity severity, const std::string &format, const nb::args &args) {
+    log(severity, formatMessage(format, args));
+  }
+
+  void vlog(LppSeverity severity, int verbose_level, const nb::object &message) {
+    if (verbosity_ >= verbose_level) {
+      log(severity, message);
+    }
+  }
+
+  void vlogIf(LppSeverity severity, int verbose_level, bool condition, const nb::object &message) {
+    if (condition) {
+      vlog(severity, verbose_level, message);
+    }
+  }
+
+  void vlogEvery(LppSeverity severity, int verbose_level, unsigned int n, const nb::object &message, const nb::object &key) {
+    if (verbosity_ >= verbose_level) {
+      logEvery(severity, n, message, key);
+    }
+  }
+
+  void vlogIfEvery(LppSeverity severity,
+                   int verbose_level,
+                   bool condition,
+                   unsigned int n,
+                   const nb::object &message,
+                   const nb::object &key) {
+    if (condition) {
+      vlogEvery(severity, verbose_level, n, message, key);
+    }
+  }
+
+ private:
+  static void validateCount(unsigned int n) {
+    if (n == 0U) {
+      throw std::invalid_argument("n must be greater than zero");
+    }
+  }
+
+  void emit(BaseSeverity severity, const std::string &message) {
+    if (mode_ == LogMode::MODE_NOLOG) {
+      return;
+    }
+
+    if (mode_ == LogMode::MODE_SYSD) {
+      emitSysd(severity, message);
+      return;
+    }
+
+    if (mode_ == LogMode::MODE_LPP && callback_.ptr() != Py_None) {
+      callback_(toLppSeverity(severity), message);
+      return;
+    }
+
+    std::cout << severityPrefix(severity) << message << std::endl;
+  }
+
+  void emitSysd(BaseSeverity severity, const std::string &message) {
+#ifdef NDEBUG
+    if (severity == BaseSeverity::DEBUG) {
+      return;
+    }
+#endif
+    if (sysd_sender_.ptr() != Py_None) {
+      sysd_sender_(toLppSeverity(severity), message, identifier_);
+      return;
+    }
+#ifdef LPP_PY_SYSD_SUPPORTED
+    sendToJournal(severity, message, identifier_);
+#endif
+  }
+
+  LogMode mode_;
+  std::string identifier_;
+  nb::object callback_;
+  int verbosity_;
+  nb::object sysd_sender_;
+  std::unordered_map<std::string, unsigned int> every_counters_;
+  std::unordered_map<std::string, unsigned int> first_counters_;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point> timed_last_log_;
+};
+
+}  // namespace lpp::python
+
+NB_MODULE(_lpp, m) {
+  m.doc() = "Log++ Python bindings.";
+
+  nb::enum_<lpp::internal::LppSeverity>(m, "LppSeverity")
+      .value("D", lpp::internal::LppSeverity::D)
+      .value("I", lpp::internal::LppSeverity::I)
+      .value("W", lpp::internal::LppSeverity::W)
+      .value("E", lpp::internal::LppSeverity::E)
+      .value("F", lpp::internal::LppSeverity::F);
+
+  nb::enum_<lpp::python::LogMode>(m, "LogMode")
+      .value("MODE_LPP", lpp::python::LogMode::MODE_LPP)
+      .value("MODE_SYSD", lpp::python::LogMode::MODE_SYSD)
+      .value("MODE_NOLOG", lpp::python::LogMode::MODE_NOLOG)
+      .value("MODE_DEFAULT", lpp::python::LogMode::MODE_DEFAULT)
+      .value("MODE_GLOG", lpp::python::LogMode::MODE_GLOG)
+      .value("MODE_ROSLOG", lpp::python::LogMode::MODE_ROSLOG);
+
+  nb::class_<lpp::python::Logger>(m, "Logger")
+      .def(nb::init<lpp::python::LogMode, nb::object, nb::object, int, nb::object>(),
+           "mode"_a = lpp::python::LogMode::MODE_LPP,
+           "identifier"_a = nb::none(),
+           "callback"_a = nb::none(),
+           "verbosity"_a = 0,
+           "sysd_sender"_a = nb::none())
+      .def("log", &lpp::python::Logger::log, "severity"_a, "message"_a)
+      .def("log_if", &lpp::python::Logger::logIf, "severity"_a, "condition"_a, "message"_a)
+      .def("log_every", &lpp::python::Logger::logEvery, "severity"_a, "n"_a, "message"_a, "key"_a = nb::none())
+      .def("log_first", &lpp::python::Logger::logFirst, "severity"_a, "n"_a, "message"_a, "key"_a = nb::none())
+      .def("log_timed", &lpp::python::Logger::logTimed, "severity"_a, "seconds"_a, "message"_a, "key"_a = nb::none())
+      .def("log_string", &lpp::python::Logger::logString, "severity"_a, "message"_a, "sink"_a = nb::none())
+      .def("log_format",
+           [](lpp::python::Logger &self,
+              lpp::internal::LppSeverity severity,
+              const std::string &format,
+              const nb::args &args) { self.logFormat(severity, format, args); })
+      .def("vlog", &lpp::python::Logger::vlog, "severity"_a, "verbose_level"_a, "message"_a)
+      .def("vlog_if", &lpp::python::Logger::vlogIf, "severity"_a, "verbose_level"_a, "condition"_a, "message"_a)
+      .def("vlog_every",
+           &lpp::python::Logger::vlogEvery,
+           "severity"_a,
+           "verbose_level"_a,
+           "n"_a,
+           "message"_a,
+           "key"_a = nb::none())
+      .def("vlog_if_every",
+           &lpp::python::Logger::vlogIfEvery,
+           "severity"_a,
+           "verbose_level"_a,
+           "condition"_a,
+           "n"_a,
+           "message"_a,
+           "key"_a = nb::none());
+}

--- a/test/python/test_lpp_bindings.py
+++ b/test/python/test_lpp_bindings.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 
@@ -213,6 +214,59 @@ def test_sysd_mode_can_use_test_sender(capfd):
 
     assert capfd.readouterr().out == ""
     assert entries == [(LppSeverity.I, "Test123", "pytest-lpp")]
+
+
+def test_sysd_mode_defaults_identifier_to_process_name(monkeypatch, capfd):
+    entries = []
+
+    def sender(severity, message, identifier):
+        entries.append((severity, message, identifier))
+
+    monkeypatch.setattr(sys, "argv", ["/usr/bin/my-process"])
+    logger = make_logger(
+        LppHandler(LogMode.MODE_SYSD, sysd_sender=sender),
+        name="test-lpp-sysd-default-identifier",
+    )
+
+    logger.info("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.I, "Test123", "my-process")]
+
+
+def test_sysd_mode_defaults_empty_identifier_when_argv0_is_empty(monkeypatch, capfd):
+    entries = []
+
+    def sender(severity, message, identifier):
+        entries.append((severity, message, identifier))
+
+    monkeypatch.setattr(sys, "argv", [""])
+    logger = make_logger(
+        LppHandler(LogMode.MODE_SYSD, sysd_sender=sender),
+        name="test-lpp-sysd-empty-argv0",
+    )
+
+    logger.info("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.I, "Test123", "")]
+
+
+def test_sysd_mode_allows_empty_identifier(capfd):
+    entries = []
+
+    def sender(severity, message, identifier):
+        entries.append((severity, message, identifier))
+
+    logger = make_logger(
+        LppHandler(LogMode.MODE_SYSD, identifier="", sysd_sender=sender),
+        name="test-lpp-sysd-empty-identifier",
+    )
+
+    logger.info("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.I, "Test123", "")]
 
 
 @pytest.mark.parametrize("mode", [LogMode.MODE_GLOG, LogMode.MODE_ROSLOG])

--- a/test/python/test_lpp_bindings.py
+++ b/test/python/test_lpp_bindings.py
@@ -1,0 +1,221 @@
+import logging
+
+import pytest
+
+from lpp import LogMode, Logger, LppHandler, LppSeverity
+
+
+LEVEL_CASES = [
+    (logging.DEBUG, "debug", "DEBUG ", LppSeverity.D),
+    (logging.INFO, "info", "INFO  ", LppSeverity.I),
+    (logging.WARNING, "warning", "WARN  ", LppSeverity.W),
+    (logging.ERROR, "error", "ERROR ", LppSeverity.E),
+    (logging.CRITICAL, "critical", "FATAL ", LppSeverity.F),
+]
+
+
+def make_logger(handler, name="test-lpp"):
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    return logger
+
+
+def test_import_smoke():
+    assert Logger is not None
+    assert LppHandler is not None
+    assert LogMode.MODE_LPP is not None
+    assert LppSeverity.I is not None
+
+
+def test_logger_factory_returns_standard_logger():
+    logger = Logger("test-lpp-factory-standard")
+
+    assert isinstance(logger, logging.Logger)
+
+
+def test_logger_factory_uses_lpp_format(capfd):
+    logger = Logger("test-lpp-factory-format")
+
+    logger.info("Test123")
+
+    assert capfd.readouterr().out == "INFO  Test123\n"
+
+
+def test_logger_factory_accepts_mode(capfd):
+    logger = Logger("test-lpp-factory-nolog", LogMode.MODE_NOLOG)
+
+    logger.info("Test123")
+
+    assert capfd.readouterr().out == ""
+
+
+def test_logger_factory_default_level_is_info(capfd):
+    logger = Logger("test-lpp-factory-default-level")
+
+    logger.debug("Hidden")
+    logger.info("Visible")
+
+    assert capfd.readouterr().out == "INFO  Visible\n"
+
+
+def test_logger_factory_accepts_level(capfd):
+    logger = Logger("test-lpp-factory-debug-level", level=logging.DEBUG)
+
+    logger.debug("Visible")
+
+    assert capfd.readouterr().out == "DEBUG Visible\n"
+
+
+def test_logger_factory_is_idempotent(capfd):
+    logger = Logger("test-lpp-factory-idempotent")
+    same_logger = Logger("test-lpp-factory-idempotent")
+
+    assert same_logger is logger
+
+    logger.info("Test123")
+
+    assert capfd.readouterr().out == "INFO  Test123\n"
+
+
+def test_logger_factory_preserves_user_handlers(capfd):
+    entries = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            entries.append(record.getMessage())
+
+    logger = logging.getLogger("test-lpp-factory-user-handler")
+    logger.handlers.clear()
+    logger.addHandler(ListHandler())
+
+    Logger("test-lpp-factory-user-handler")
+    logger.info("Test123")
+
+    assert capfd.readouterr().out == "INFO  Test123\n"
+    assert entries == ["Test123"]
+
+
+def test_logger_factory_callback(capfd):
+    entries = []
+    logger = Logger(
+        "test-lpp-factory-callback",
+        callback=lambda severity, message: entries.append((severity, message)),
+    )
+
+    logger.warning("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.W, "Test123")]
+
+
+def test_logger_factory_sysd_sender(capfd):
+    entries = []
+
+    def sender(severity, message, identifier):
+        entries.append((severity, message, identifier))
+
+    logger = Logger(
+        "test-lpp-factory-sysd",
+        LogMode.MODE_SYSD,
+        identifier="pytest-lpp",
+        sysd_sender=sender,
+    )
+
+    logger.info("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.I, "Test123", "pytest-lpp")]
+
+
+@pytest.mark.parametrize(("level", "method_name", "prefix", "_severity"), LEVEL_CASES)
+def test_lpp_handler_outputs_lpp_format(capfd, level, method_name, prefix, _severity):
+    logger = make_logger(LppHandler(), name=f"test-lpp-{level}")
+
+    getattr(logger, method_name)("Test123")
+
+    assert capfd.readouterr().out == f"{prefix}Test123\n"
+
+
+def test_default_mode_uses_lpp_format(capfd):
+    logger = make_logger(LppHandler(LogMode.MODE_DEFAULT), name="test-lpp-default")
+
+    logger.info("Test123")
+
+    assert capfd.readouterr().out == "INFO  Test123\n"
+
+
+def test_python_percent_formatting(capfd):
+    logger = make_logger(LppHandler(), name="test-lpp-formatting")
+
+    logger.warning("Base angle (%f) is less than the minimum angle (%f)", 3.3, 5.5)
+
+    assert capfd.readouterr().out == "WARN  Base angle (3.300000) is less than the minimum angle (5.500000)\n"
+
+
+def test_formatter_is_respected(capfd):
+    handler = LppHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    logger = make_logger(handler, name="test-lpp-formatter")
+
+    logger.warning("Test%s", 123)
+
+    assert capfd.readouterr().out == "WARN  WARNING:Test123\n"
+
+
+@pytest.mark.parametrize(("level", "method_name", "_prefix", "severity"), LEVEL_CASES)
+def test_callback_receives_mapped_severity(capfd, level, method_name, _prefix, severity):
+    entries = []
+    handler = LppHandler(callback=lambda callback_severity, message: entries.append((callback_severity, message)))
+    logger = make_logger(handler, name=f"test-lpp-callback-{level}")
+
+    getattr(logger, method_name)("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(severity, "Test123")]
+
+
+def test_custom_low_level_maps_to_debug(capfd):
+    entries = []
+    handler = LppHandler(callback=lambda severity, message: entries.append((severity, message)))
+    logger = make_logger(handler, name="test-lpp-custom-low")
+    logger.setLevel(1)
+
+    logger.log(5, "Test123")
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.D, "Test123")]
+
+
+def test_nolog_mode_emits_nothing(capfd):
+    logger = make_logger(LppHandler(LogMode.MODE_NOLOG), name="test-lpp-nolog")
+
+    for _level, method_name, _prefix, _severity in LEVEL_CASES:
+        getattr(logger, method_name)("Test123")
+
+    assert capfd.readouterr().out == ""
+
+
+def test_sysd_mode_can_use_test_sender(capfd):
+    entries = []
+
+    def sender(severity, message, identifier):
+        entries.append((severity, message, identifier))
+
+    logger = make_logger(
+        LppHandler(LogMode.MODE_SYSD, identifier="pytest-lpp", sysd_sender=sender),
+        name="test-lpp-sysd",
+    )
+
+    logger.info("Test%s", 123)
+
+    assert capfd.readouterr().out == ""
+    assert entries == [(LppSeverity.I, "Test123", "pytest-lpp")]
+
+
+@pytest.mark.parametrize("mode", [LogMode.MODE_GLOG, LogMode.MODE_ROSLOG])
+def test_external_backends_raise_clear_error(mode):
+    with pytest.raises(RuntimeError):
+        LppHandler(mode)


### PR DESCRIPTION
- Added Python bindings for lpp
- Added support to use lpp through pythons in-built logging API 
- Updated documentation
- Added pytest testsuite and run it in CI

Example:
```python
from lpp import Logger, LogMode

logger = Logger("foo", LogMode.MODE_LPP)
logger.info("started")
logger.warning("many retries")
logger.critical("cannot continue")
```